### PR TITLE
make --watch work with vim

### DIFF
--- a/examples/hello_world.star
+++ b/examples/hello_world.star
@@ -4,3 +4,4 @@ def main():
     return render.Root(
         child = render.Text("Hello, World!"),
     )
+   

--- a/serve.go
+++ b/serve.go
@@ -77,8 +77,10 @@ func serve(cmd *cobra.Command, args []string) {
 				if !ok {
 					break
 				}
-
-				if (event.Op & fsnotify.Write) != 0 {
+				if (event.Op & fsnotify.Rename) != 0 {
+					watcher.Remove(event.Name)
+					watcher.Add(args[0])
+				} else if (event.Op & (fsnotify.Write | fsnotify.Chmod)) != 0 {
 					mutex.Lock()
 					err := loadScript(&applet, args[0])
 					mutex.Unlock()

--- a/serve.go
+++ b/serve.go
@@ -78,9 +78,14 @@ func serve(cmd *cobra.Command, args []string) {
 					break
 				}
 				if (event.Op & fsnotify.Rename) != 0 {
+					// When Vim saves a file, we get a Rename event followed
+					// by silence. Re-adding allows us to capture future
+					// events.
 					watcher.Remove(event.Name)
 					watcher.Add(args[0])
 				} else if (event.Op & (fsnotify.Write | fsnotify.Chmod)) != 0 {
+					// Reloading on Write is sufficient for most editors,
+					// but with Vim we only get Chmod. No clue why.
 					mutex.Lock()
 					err := loadScript(&applet, args[0])
 					mutex.Unlock()


### PR DESCRIPTION
Vim appears to move/rename the original file on save, resulting
in a  RENAME event from fsnotify. Reacting to this by re-adding
the original file name also catches two CHMOD (but no WRITE).

Not sure what's going on, but re-adding on RENAME and reloading
on CHMOD seems to do the trick.