### PR TITLE
Marquee scrolls vertically

### DIFF
--- a/doc/widgets.md
+++ b/doc/widgets.md
@@ -173,12 +173,17 @@ the `delay` attribute.
 
 
 ## Marquee
-Marquee scrolls its child horizontally.
+Marquee scrolls its child horizontally or vertically.
 
-The height of the Marquee will be that of its child, but its
-`width` must be specified explicitly. If the child's width fits
-fully, it will not scroll. Otherwise, it will be scrolled right to
-left.
+The `scroll_direction` will be 'horizontal' and will scroll from right
+to left if left empty, if specified as 'vertical' the Marquee will
+scroll from bottom to top.
+
+In horizontal mode the height of the Marquee will be that of its child,
+but its `width` must be specified explicitly. In vertical mode the width
+will be that of its child but the `height` must be specified explicitly.
+
+If the child's width fits fully, it will not scroll.
 
 The `offset_start` and `offset_end` parameters control the position
 of the child in the beginning and the end of the animation.
@@ -187,9 +192,11 @@ of the child in the beginning and the end of the animation.
 | Name | Type | Description | Required |
 | --- | --- | --- | --- |
 | `child` | `Widget` | Widget to potentially scroll | **Y** |
-| `width` | `int` | Width of the Marquee | **Y** |
+| `width` | `int` | Width of the Marquee, required for horizontal | N |
+| `height` | `int` | Height of the Marquee, required for vertical | N |
 | `offset_start` | `int` | Position of child at beginning of animation | N |
 | `offset_end` | `int` | Position of child at end of animation | N |
+| `scroll_direction` | `str` | Direction to scroll, 'vertical' or 'horizontal', default is horizontal | N |
 
 #### Example
 ```

--- a/render/marquee_test.go
+++ b/render/marquee_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMarqueeNoScroll(t *testing.T) {
+func TestMarqueeNoScrollHorizontal(t *testing.T) {
 	m := Marquee{
 		Width: 6,
 		Child: Row{
@@ -20,14 +20,33 @@ func TestMarqueeNoScroll(t *testing.T) {
 		},
 	}
 
+	mv := Marquee{
+		Height: 3,
+		Child: Row{
+			Children: []Widget{
+				Box{Width: 3, Height: 3, Color: color.RGBA{0xff, 0, 0, 0xff}},
+				Box{Width: 2, Height: 2, Color: color.RGBA{0, 0xff, 0, 0xff}},
+				Box{Width: 1, Height: 1, Color: color.RGBA{0, 0, 0xff, 0xff}},
+			},
+		},
+		ScrollDirection: "vertical",
+	}
+
 	// Child fits so there's just 1 single frame
 	assert.Equal(t, 1, m.FrameCount())
+	assert.Equal(t, 1, mv.FrameCount())
 	im := m.Paint(image.Rect(0, 0, 100, 100), 0)
+	imv := mv.Paint(image.Rect(0, 0, 100, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrggb",
 		"rrrgg.",
 		"rrr...",
 	}, im))
+	assert.Equal(t, nil, checkImage([]string{
+		"rrrggb",
+		"rrrgg.",
+		"rrr...",
+	}, imv))
 }
 
 // The addition of OffsetStart and OffsetEnd changes the default
@@ -271,4 +290,194 @@ func TestMarqueeOffsetEnd(t *testing.T) {
 	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 9)))
 	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 1024)))
 
+}
+
+func TestMarqueeVerticalScroll(t *testing.T) {
+	child := Column{
+		Children: []Widget{
+			Box{Width: 1, Height: 1, Color: color.RGBA{0xff, 0, 0, 0xff}},
+			Box{Width: 1, Height: 2, Color: color.RGBA{0, 0xff, 0, 0xff}},
+			Box{Width: 1, Height: 4, Color: color.RGBA{0, 0, 0xff, 0xff}},
+		},
+	}
+	m := Marquee{
+		Height:          6,
+		Child:           child,
+		ScrollDirection: "vertical",
+	}
+	im := image.Rect(0, 0, 100, 100)
+
+	// OffsetEnd affects the final position of the child
+	m.OffsetStart = 2
+	assert.Equal(t, nil, checkImage([]string{
+		".",
+		".",
+		"r",
+		"g",
+		"g",
+		"b",
+	}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{
+		".",
+		"r",
+		"g",
+		"g",
+		"b",
+		"b",
+	}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{
+		"r",
+		"g",
+		"g",
+		"b",
+		"b",
+		"b",
+	}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{
+		"g",
+		"g",
+		"b",
+		"b",
+		"b",
+		"b",
+	}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{
+		"g",
+		"b",
+		"b",
+		"b",
+		"b",
+		".",
+	}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{
+		"b",
+		"b",
+		"b",
+		"b",
+		".",
+		".",
+	}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{
+		"b",
+		"b",
+		"b",
+		".",
+		".",
+		".",
+	}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{
+		"b",
+		"b",
+		".",
+		".",
+		".",
+		".",
+	}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{
+		"b",
+		".",
+		".",
+		".",
+		".",
+		".",
+	}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{
+		".",
+		".",
+		".",
+		".",
+		".",
+		".",
+	}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 13)))
+	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, m.Paint(im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 15)))
+	assert.Equal(t, 16, m.FrameCount())
+
+	// Negative OffsetStart
+	m.OffsetStart = -2
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", ".", ".", ".", "."}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 11)))
+	assert.Equal(t, 12, m.FrameCount())
+
+	// Overly negative OffsetStart is truncated to child width
+	m.OffsetStart = -1000
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 2)))
+	assert.Equal(t, 7, m.FrameCount())
+	m.OffsetStart = -7
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 1)))
+	assert.Equal(t, 7, m.FrameCount())
+	m.OffsetStart = -8
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 1)))
+	assert.Equal(t, 7, m.FrameCount())
+	m.OffsetStart = -6
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 2)))
+	assert.Equal(t, 8, m.FrameCount())
+
+	// OffsetEnd affects the final position of the child
+	m.OffsetStart = 0
+	m.OffsetEnd = 2
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", ".", ".", ".", "."}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 11)))
+	assert.Equal(t, 12, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 13)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 1024)))
+
+	// Negative offset places child outside of marquee
+	m.OffsetEnd = -4
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 13)))
+	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, m.Paint(im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 15)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, m.Paint(im, 16)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 17)))
+	assert.Equal(t, 18, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 18)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 19)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 1024)))
+
+	// OffsetEnd >= width means it doesn't scroll back
+	m.OffsetEnd = 6
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 7)))
+	assert.Equal(t, 8, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 1024)))
 }

--- a/runtime/generated.go
+++ b/runtime/generated.go
@@ -594,7 +594,10 @@ func newMarquee(
 ) (starlark.Value, error) {
 
 	var (
+		scroll_direction starlark.String
+
 		width        starlark.Int
+		height       starlark.Int
 		offset_start starlark.Int
 		offset_end   starlark.Int
 
@@ -605,15 +608,19 @@ func newMarquee(
 		"Marquee",
 		args, kwargs,
 		"child", &child,
-		"width", &width,
+		"width?", &width,
+		"height?", &height,
 		"offset_start?", &offset_start,
 		"offset_end?", &offset_end,
+		"scroll_direction?", &scroll_direction,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Marquee: %s", err)
 	}
 
 	w := &Marquee{}
+	w.ScrollDirection = scroll_direction.GoString()
 	w.Width = int(width.BigInt().Int64())
+	w.Height = int(height.BigInt().Int64())
 	w.OffsetStart = int(offset_start.BigInt().Int64())
 	w.OffsetEnd = int(offset_end.BigInt().Int64())
 
@@ -638,15 +645,21 @@ func (w *Marquee) AsRenderWidget() render.Widget {
 
 func (w *Marquee) AttrNames() []string {
 	return []string{
-		"child", "width", "offset_start", "offset_end",
+		"child", "width", "height", "offset_start", "offset_end", "scroll_direction",
 	}
 }
 
 func (w *Marquee) Attr(name string) (starlark.Value, error) {
 	switch name {
 
+	case "scroll_direction":
+		return starlark.String(w.ScrollDirection), nil
+
 	case "width":
 		return starlark.MakeInt(w.Width), nil
+
+	case "height":
+		return starlark.MakeInt(w.Height), nil
 
 	case "offset_start":
 		return starlark.MakeInt(w.OffsetStart), nil


### PR DESCRIPTION
Now marquee will accept the scroll_direction parameter. If left empty it
will scroll horizontally like allways. If set to 'vertical' it will
scroll bottom to top. Offsets work as expected.

Usage example:
```starlark
load("render.star", "render")

TEXT = "The vilification of Liz Cheney and a bizarre vote\
     recount in Arizona showed the damage from his assault on a bedrock\
    of democracy: election integrity."

def main(config):
    return render.Root(
        delay=100,
        child=render.Marquee(
            height=32,
            child=render.WrappedText(
                content=TEXT,
                height=112,
            ),
            scroll_direction="vertical"
        )
    )
```

![vertical](https://user-images.githubusercontent.com/27937411/118195799-4dacf380-b422-11eb-80e4-ffe1f98bcce9.gif)
