### PR TITLE
Added fully qualified URL.

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	host string
+	host  string
 	port  int
 	watch bool
 )
@@ -131,7 +131,7 @@ func serve(cmd *cobra.Command, args []string) {
 		w.Header().Set("Content-Type", "text/html")
 		writePreviewHTML(w, webp)
 	})
-	fmt.Printf("listening on tcp/%d\n", port)
+	fmt.Printf("listening at http://%s:%d\n", host, port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", host, port), nil))
 }
 


### PR DESCRIPTION
This commit adds a fully qualified URL to be able to Command+Click from a terminal like iTerm2 and have it open the browser for the serve command:
```
$ pixlet serve examples/clock.star
listening at http://127.0.0.1:8080
```
![Screen Shot 2021-06-14 at 6 12 18 PM](https://user-images.githubusercontent.com/3886576/121966257-4be59100-cd3c-11eb-81d6-8e6666b63cd2.png)
