### PR TITLE
Update to hashstructure/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/harukasan/go-libwebp v0.0.0-20190703060927-68562c9c99af
 	github.com/lucasb-eyer/go-colorful v1.2.0
-	github.com/mitchellh/hashstructure v1.1.0
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/pkg/errors v0.9.1
 	github.com/qri-io/starlib v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
 github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/runtime/animatedpositioned.go
+++ b/runtime/animatedpositioned.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"fmt"
 
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.starlark.net/starlark"
 
 	"tidbyt.dev/pixlet/render"
@@ -93,6 +93,6 @@ func (ap AnimatedPositioned) Freeze()              {}
 func (ap AnimatedPositioned) Truth() starlark.Bool { return true }
 
 func (ap AnimatedPositioned) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(ap, nil)
+	sum, err := hashstructure.Hash(ap, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }

--- a/runtime/frame.go
+++ b/runtime/frame.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"fmt"
 
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.starlark.net/starlark"
 
 	"tidbyt.dev/pixlet/render"
@@ -73,6 +73,6 @@ func (r Root) Freeze()              {}
 func (r Root) Truth() starlark.Bool { return true }
 
 func (r Root) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(r, nil)
+	sum, err := hashstructure.Hash(r, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }

--- a/runtime/gen/header.tmpl
+++ b/runtime/gen/header.tmpl
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/lucasb-eyer/go-colorful"
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"tidbyt.dev/pixlet/render"

--- a/runtime/gen/widget.tmpl
+++ b/runtime/gen/widget.tmpl
@@ -215,7 +215,7 @@ func (w *{{.Name}}) Freeze()              {}
 func (w *{{.Name}}) Truth() starlark.Bool { return true }
 
 func (w *{{.Name}}) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 

--- a/runtime/generated.go
+++ b/runtime/generated.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/lucasb-eyer/go-colorful"
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"tidbyt.dev/pixlet/render"
@@ -153,7 +153,7 @@ func (w *Animation) Freeze()              {}
 func (w *Animation) Truth() starlark.Bool { return true }
 
 func (w *Animation) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -267,7 +267,7 @@ func (w *Box) Freeze()              {}
 func (w *Box) Truth() starlark.Bool { return true }
 
 func (w *Box) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -369,7 +369,7 @@ func (w *Circle) Freeze()              {}
 func (w *Circle) Truth() starlark.Bool { return true }
 
 func (w *Circle) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -472,7 +472,7 @@ func (w *Column) Freeze()              {}
 func (w *Column) Truth() starlark.Bool { return true }
 
 func (w *Column) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -560,7 +560,7 @@ func (w *Image) Freeze()              {}
 func (w *Image) Truth() starlark.Bool { return true }
 
 func (w *Image) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -681,7 +681,7 @@ func (w *Marquee) Freeze()              {}
 func (w *Marquee) Truth() starlark.Bool { return true }
 
 func (w *Marquee) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -802,7 +802,7 @@ func (w *Padding) Freeze()              {}
 func (w *Padding) Truth() starlark.Bool { return true }
 
 func (w *Padding) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -905,7 +905,7 @@ func (w *Row) Freeze()              {}
 func (w *Row) Truth() starlark.Bool { return true }
 
 func (w *Row) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -988,7 +988,7 @@ func (w *Stack) Freeze()              {}
 func (w *Stack) Truth() starlark.Bool { return true }
 
 func (w *Stack) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -1100,7 +1100,7 @@ func (w *Text) Freeze()              {}
 func (w *Text) Truth() starlark.Bool { return true }
 
 func (w *Text) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }
 
@@ -1222,6 +1222,6 @@ func (w *WrappedText) Freeze()              {}
 func (w *WrappedText) Truth() starlark.Bool { return true }
 
 func (w *WrappedText) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(w, nil)
+	sum, err := hashstructure.Hash(w, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }

--- a/runtime/plot.go
+++ b/runtime/plot.go
@@ -6,7 +6,7 @@ import (
 	gocolor "image/color"
 
 	"github.com/lucasb-eyer/go-colorful"
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.starlark.net/starlark"
 
 	"tidbyt.dev/pixlet/render"
@@ -196,6 +196,6 @@ func (p Plot) Freeze()              {}
 func (p Plot) Truth() starlark.Bool { return true }
 
 func (p Plot) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(p, nil)
+	sum, err := hashstructure.Hash(p, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }

--- a/runtime/xpath.go
+++ b/runtime/xpath.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/antchfx/xmlquery"
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -141,6 +141,6 @@ func (x *XPath) Freeze()              {}
 func (x *XPath) Truth() starlark.Bool { return true }
 
 func (x *XPath) Hash() (uint32, error) {
-	sum, err := hashstructure.Hash(x, nil)
+	sum, err := hashstructure.Hash(x, hashstructure.FormatV2, nil)
 	return uint32(sum), err
 }


### PR DESCRIPTION
From the docs:

> It is highly recommended you use the "v2" release since this fixes some
> significant hash collisions issues from v1.