### PR TITLE
runtime: Add support for customizing the Starlark thread

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -217,6 +217,32 @@ def main():
 
 }
 
+func TestThreadInitializer(t *testing.T) {
+	src := `
+load("render.star", "render")
+def main():
+	print('foobar')
+	return render.Root(child=render.Box())
+`
+	// override the print function of the thread
+	var printedText string
+	initializer := func(thread *starlark.Thread) *starlark.Thread {
+		thread.Print = func(thread *starlark.Thread, msg string) {
+			printedText += msg
+		}
+		return thread
+	}
+
+	app := &Applet{}
+	err := app.Load("test.star", []byte(src), nil)
+	assert.NoError(t, err)
+	_, err = app.Run(map[string]string{}, initializer)
+	assert.NoError(t, err)
+
+	// our print function should have been called
+	assert.Equal(t, "foobar", printedText)
+}
+
 func TestXPathModule(t *testing.T) {
 	src := `
 load("render.star", r="render")


### PR DESCRIPTION
Add support for an optional `ThreadInitializer`, which is called when building
a Starlark thread to run an applet on. It can customize the thread by
overriding behavior or attaching thread local data.