### PR TITLE
fix: Standardizes the way we build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
       run: brew install webp
 
     - name: Build & test
-      run: go build . && go test ./...
+      run: make build && make test

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ examples/*.webp
 examples/*.gif
 
 # Pixlet Binary
-build/out/pixlet
+pixlet

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,9 +17,9 @@ Steps
 	```console
 	cd pixlet
 	```
-- Build the following directories in order: `/render`, then `/runtime`, then `/encode` and finally `/`:
+- Build the binary:
 	```console
-	go build render runtime encode .
+	make build
 	```
 - After that you will have the binary `/pixlet`, which you should copy to your path.
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
 
-build: clean embedfonts
+build: clean
 	go build -o build/out/pixlet tidbyt.dev/pixlet
 
 embedfonts:

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ test:
 	go test -v -cover ./...
 
 clean:
-	rm -rf build/out
+	rm -f pixlet
 
 bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
 
 build: clean
-	go build -o build/out/pixlet tidbyt.dev/pixlet
+	go build -o pixlet tidbyt.dev/pixlet
 
 embedfonts:
 	go run render/gen/embedfonts.go


### PR DESCRIPTION
# Overview
We have several different ways to build this repo currently:
- The method outlined in the build docs, which is now not working
- The method in the Makefile
- The method in the github action file
- A private method defined internally at Tidbyt 😄 

This change standardizes the way we build this repo so there's less confusion around how it's built. Additionally, any changes to the way we build `pixlet` will work the same way in CI and local development.

# Changes
- Remove font embedding from build.
    - I added this when I was doing a lot of font work, but now that I'm not it really is annoying to generate fonts each time. This commit makes it so the only target for build is a clean.
- Remove build directory in make. 
    - This is unnecessary and I feel bad for adding it. I've removed it so that a build places the binary in the root.
- Updated build to use make.
    - This commit updates the build to use make so there is one way to build things.
- Updated build docs.
    - This commit updates the build docs to use the one true way to build this repository.    

# Tests
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|mark/fix-build-docs ⇒  make build
rm pixlet
go build -o pixlet tidbyt.dev/pixlet
```
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|mark/fix-build-docs ⇒  ./pixlet
Pixlet renders graphics for pixel devices, like Tidbyt

Usage:
  pixlet [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  push        Pushes a webp image to a Tidbyt device
  render      Runs script with provided config parameters.
  serve       Serves a starlark render script over HTTP.

Flags:
  -h, --help   help for pixlet

Use "pixlet [command] --help" for more information about a command.
```
