### PR TITLE
Added release scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ examples/*.gif
 
 # Pixlet Binary
 pixlet
+
+# Releases
+build/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ test:
 
 clean:
 	rm -f pixlet
+	rm -rf ./build
 
 bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
@@ -12,3 +13,9 @@ build: clean
 
 embedfonts:
 	go run render/gen/embedfonts.go
+
+release-macos: clean
+	./scripts/release-macos.sh
+
+release-linux: clean
+	./scripts/release-linux.sh

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z "$RELEASE_ARCHS" ]; then
+	echo "Please set RELEASE_ARCHS"
+	exit 1
+fi
+
+if [ -z "$RELEASE_PLATFORM" ]; then
+	echo "Please set RELEASE_PLATFORM"
+	exit 1
+fi
+
+for ARCH in $RELEASE_ARCHS
+do
+	if [[ $ARCH == *arm*  ]]; then
+		RELEASE_ARCH=arm64
+	else
+		RELEASE_ARCH=amd64
+	fi
+
+	echo "Building ${RELEASE_PLATFORM}_${RELEASE_ARCH}"
+
+	if [[ $ARCH == "linux-arm64"  ]]; then
+		 CC=aarch64-linux-gnu-gcc CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/usr/include/webp" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/usr/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+	else
+		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+	fi
+
+	echo "Built ./build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet successfully"
+done

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,7 +21,9 @@ do
 	echo "Building ${RELEASE_PLATFORM}_${RELEASE_ARCH}"
 
 	if [[ $ARCH == "linux-arm64"  ]]; then
-		 CC=aarch64-linux-gnu-gcc CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/usr/include/webp" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/usr/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+		 CC=aarch64-linux-gnu-gcc CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+	elif [[ $ARCH == "linux-amd64"  ]]; then
+		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	else
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	fi

--- a/scripts/fetch-deps.sh
+++ b/scripts/fetch-deps.sh
@@ -17,9 +17,6 @@ pushd "/tmp/$LIBWEBP_VERSION" > /dev/null
 # WebP release signing key.
 gpg --receive-keys --keyserver hkps://keyserver.ubuntu.com 6B0E6B70976DE303EDF2F601F9C3D6BDB8232B5D 2>/dev/null
 
-# Arch Linux ARM Build System.
-gpg --receive-keys --keyserver hkps://keyserver.ubuntu.com 68B3537F39A313B3E574D06777193F152BDBE6A6 2>/dev/null
-
 echo "Fetching WebP Binaries"
 for ARCH in $RELEASE_ARCHS
 do
@@ -28,16 +25,6 @@ do
 		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.zip.asc"
 		gpg --verify "${LIBWEBP_VERSION}-${ARCH}.zip.asc" "${LIBWEBP_VERSION}-${ARCH}.zip" 2>/dev/null
 		unzip -q "${LIBWEBP_VERSION}-${ARCH}.zip" -d "${ARCH}"
-	elif [[ $ARCH == "linux-arm64"  ]]; then
-		# TODO: there is no official release for aarch64, so we need to find it elsewhere. Unfortunately, we need
-		# the RC version to get macOS M1 support. The RC version is not available under this mirror so we are
-		# using a different version. It feels bad, but it allows us to build for all target platforms in the short
-		# term.
-		curl -sLO "http://mirror.archlinuxarm.org/aarch64/extra/libwebp-1.2.1-2-aarch64.pkg.tar.xz"
-		curl -sLO "http://mirror.archlinuxarm.org/aarch64/extra/libwebp-1.2.1-2-aarch64.pkg.tar.xz.sig"
-		gpg --verify "libwebp-1.2.1-2-aarch64.pkg.tar.xz.sig" "libwebp-1.2.1-2-aarch64.pkg.tar.xz" 2>/dev/null
-		mkdir "linux-arm64"
-		tar -xf libwebp-1.2.1-2-aarch64.pkg.tar.xz -C "linux-arm64"
 	else
 		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.tar.gz"
 		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.tar.gz.asc"

--- a/scripts/fetch-deps.sh
+++ b/scripts/fetch-deps.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if [ -z "$LIBWEBP_VERSION" ]; then
+	echo "Please set LIBWEBP_VERSION"
+	exit 1
+fi
+
+if [ -z "$RELEASE_ARCHS" ]; then
+	echo "Please set RELEASE_ARCHS"
+	exit 1
+fi
+
+rm -rf "/tmp/${LIBWEBP_VERSION}"
+mkdir -p "/tmp/$LIBWEBP_VERSION"
+pushd "/tmp/$LIBWEBP_VERSION" > /dev/null
+
+# WebP release signing key.
+gpg --receive-keys --keyserver hkps://keyserver.ubuntu.com 6B0E6B70976DE303EDF2F601F9C3D6BDB8232B5D 2>/dev/null
+
+# Arch Linux ARM Build System.
+gpg --receive-keys --keyserver hkps://keyserver.ubuntu.com 68B3537F39A313B3E574D06777193F152BDBE6A6 2>/dev/null
+
+echo "Fetching WebP Binaries"
+for ARCH in $RELEASE_ARCHS
+do
+	if [[ $ARCH == windows* ]]; then
+		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.zip"
+		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.zip.asc"
+		gpg --verify "${LIBWEBP_VERSION}-${ARCH}.zip.asc" "${LIBWEBP_VERSION}-${ARCH}.zip" 2>/dev/null
+		unzip -q "${LIBWEBP_VERSION}-${ARCH}.zip" -d "${ARCH}"
+	elif [[ $ARCH == "linux-arm64"  ]]; then
+		# TODO: there is no official release for aarch64, so we need to find it elsewhere. Unfortunately, we need
+		# the RC version to get macOS M1 support. The RC version is not available under this mirror so we are
+		# using a different version. It feels bad, but it allows us to build for all target platforms in the short
+		# term.
+		curl -sLO "http://mirror.archlinuxarm.org/aarch64/extra/libwebp-1.2.1-2-aarch64.pkg.tar.xz"
+		curl -sLO "http://mirror.archlinuxarm.org/aarch64/extra/libwebp-1.2.1-2-aarch64.pkg.tar.xz.sig"
+		gpg --verify "libwebp-1.2.1-2-aarch64.pkg.tar.xz.sig" "libwebp-1.2.1-2-aarch64.pkg.tar.xz" 2>/dev/null
+		mkdir "linux-arm64"
+		tar -xf libwebp-1.2.1-2-aarch64.pkg.tar.xz -C "linux-arm64"
+	else
+		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.tar.gz"
+		curl -sLO "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${LIBWEBP_VERSION}-${ARCH}.tar.gz.asc"
+		gpg --verify "${LIBWEBP_VERSION}-${ARCH}.tar.gz.asc" "${LIBWEBP_VERSION}-${ARCH}.tar.gz" 2>/dev/null
+		tar -xf "${LIBWEBP_VERSION}-${ARCH}.tar.gz"
+		mv "${LIBWEBP_VERSION}-${ARCH}" "${ARCH}"
+	fi
+
+	echo "Fetched /tmp/${LIBWEBP_VERSION}/${ARCH} successfully"
+done
+
+popd > /dev/null

--- a/scripts/release-linux.sh
+++ b/scripts/release-linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+export RELEASE_ARCHS="linux-x86-64 linux-arm64"
+export RELEASE_PLATFORM="linux"
+
+source scripts/set-libwebp-version.sh
+source scripts/fetch-deps.sh
+source scripts/build-release.sh

--- a/scripts/release-linux.sh
+++ b/scripts/release-linux.sh
@@ -5,6 +5,25 @@ set -e
 export RELEASE_ARCHS="linux-x86-64 linux-arm64"
 export RELEASE_PLATFORM="linux"
 
-source scripts/set-libwebp-version.sh
-source scripts/fetch-deps.sh
+# In order to build release packages on Ubuntu, you'll need the following.
+#
+# Add arm64 architecture:
+# sudo dpkg --add-architecture arm64
+#
+# Update apt sources in  /etc/apt/sources.list to include ubuntu-ports for amr64 support:
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal universe
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates universe
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal multiverse
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates multiverse
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main restricted
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security universe
+# deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security multiverse
+#
+# Install packages:
+# sudo apt update
+# sudo apt install -y libwebp-dev libwebp-dev:arm64
+
 source scripts/build-release.sh

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+export RELEASE_ARCHS="mac-arm64 mac-x86-64"
+export RELEASE_PLATFORM="darwin"
+
+source scripts/set-libwebp-version.sh
+source scripts/fetch-deps.sh
+source scripts/build-release.sh

--- a/scripts/set-libwebp-version.sh
+++ b/scripts/set-libwebp-version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export LIBWEBP_VERSION="libwebp-1.2.2-rc1"


### PR DESCRIPTION
# Overview
This change adds a set of scripts to be able to cross compile for different CPU architectures to support changes in #81 . For example, we can compile both MacOS and MacOS M1 or Linux amd64 and Linux arm64 on each platform respectively. These scripts make the assumption that the compilation is happening on the target platform. In an ideal world, we would cross-compile both architecture and platform, but it would require more work to setup our build agents to handle that.


# Changes
- Added release scripts.
    - This commit adds release scripts that can cross compile with CGO support for MacOS and Linux for both x86_64 and arm64 based CPU architectures. It assumes that each build is being build on the target platform though. Cross compiling the world on Linux would be ideal, but it would require all of those toolchains to be setup on our build hosts. Doable, but I'll leave it for a future exercise.
    
# Requirements
If you want to release on a Debain based system, you will need to install the ARM compiler `aarch64-linux-gnu-gcc`, which is included in `crossbuild-essential-arm64`:
```
sudo apt install crossbuild-essential-arm64
```

In order to release on MacOS, you'll need to install gpg to verify signatures:
```
brew install gnupg
```

In addition, you will need `Xcode 12.2` or later to be able to [support the M1 compilation](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary):
> Xcode 12.2 and later is a requirement for building universal binaries. Earlier versions of Xcode don’t contain the support needed to build and test universal versions of your macOS code.
    
# Tests
## Linux
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|mark/release-scripts ⇒  make release-linux
rm -f pixlet
rm -rf ./build
./scripts/release-linux.sh
Fetching WebP Binaries
Fetched /tmp/libwebp-1.2.2-rc1/linux-x86-64 successfully
Fetched /tmp/libwebp-1.2.2-rc1/linux-arm64 successfully
Building linux_amd64
Built ./build/linux_amd64/pixlet successfully
Building linux_arm64
Built ./build/linux_arm64/pixlet successfully
```
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|mark/release-scripts ⇒  ./build/linux_amd64/pixlet
Pixlet renders graphics for pixel devices, like Tidbyt

Usage:
  pixlet [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  push        Pushes a webp image to a Tidbyt device
  render      Runs script with provided config parameters.
  serve       Serves a starlark render script over HTTP.

Flags:
  -h, --help   help for pixlet

Use "pixlet [command] --help" for more information about a command.
```
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|mark/release-scripts ⇒  ./build/linux_arm64/pixlet
zsh: exec format error: ./build/linux_arm64/pixlet
```
## MacOS
```
mspicer@americano:~/code/src/tidbyt.dev/pixlet|mark/release-scripts ⇒  make release-macos
rm -f pixlet
rm -rf ./build
./scripts/release-macos.sh
Fetching WebP Binaries
Fetched /tmp/libwebp-1.2.2-rc1/mac-arm64 successfully
Fetched /tmp/libwebp-1.2.2-rc1/mac-x86-64 successfully
Building darwin_arm64
Built ./build/darwin_arm64/pixlet successfully
Building darwin_amd64
Built ./build/darwin_amd64/pixlet successfully
```
```
mspicer@americano:~/code/src/tidbyt.dev/pixlet|mark/release-scripts ⇒  ./build/darwin_amd64/pixlet
Pixlet renders graphics for pixel devices, like Tidbyt

Usage:
  pixlet [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  push        Pushes a webp image to a Tidbyt device
  render      Runs script with provided config parameters.
  serve       Serves a starlark render script over HTTP.

Flags:
  -h, --help   help for pixlet

Use "pixlet [command] --help" for more information about a command.
```
```
mspicer@americano:~/code/src/tidbyt.dev/pixlet|mark/release-scripts ⇒  ./build/darwin_arm64/pixlet
zsh: bad CPU type in executable: ./build/darwin_arm64/pixlet
```