### PR TITLE
Fix(examples): life example render issue

### DIFF
--- a/examples/life.star
+++ b/examples/life.star
@@ -337,7 +337,7 @@ def seed_board(board, width, height, num_start):
     Modifies a given board with the desired number of starting live cells, placed randomly.
     """
     current = 0
-    seed = time.now().nanosecond()
+    seed = time.now().nanosecond
 
     while current < num_start:
         x, seed = random(seed)


### PR DESCRIPTION
Previously when attempting to render the life simulation the render would fail due to a non function being called

<img width="666" alt="Screen Shot 2021-12-28 at 7 16 42 PM" src="https://user-images.githubusercontent.com/36527018/147624307-758f5eae-ed4f-4f34-9a7d-cf7a6e26c478.png">

This was caused as `time.now().nanoseconds` is a property and not a function and has since been resolved. 