### PR TITLE
Moved installation ID to flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Pushing an applet to your Tidbyt without an installation ID simply displays your
 
 ```
 pixlet render examples/bitcoin.star
-pixlet push --api-token <YOUR API TOKEN> <YOUR DEVICE ID> examples/bitcoin.webp <INSTALLATION ID>
+pixlet push --api-token <YOUR API TOKEN> --installation-id <INSTALLATION ID> <YOUR DEVICE ID> examples/bitcoin.webp
 ```
 
 For example, if we set the `installationID` to "Bitcoin", it would appear in the mobile app as follows:

--- a/push.go
+++ b/push.go
@@ -18,8 +18,9 @@ const (
 )
 
 var (
-	apiToken   string
-	background bool
+	apiToken       string
+	installationID string
+	background     bool
 )
 
 type TidbytPushJSON struct {
@@ -32,6 +33,7 @@ type TidbytPushJSON struct {
 func init() {
 	rootCmd.AddCommand(pushCmd)
 	pushCmd.Flags().StringVarP(&apiToken, "api-token", "t", "", "Tidbyt API token")
+	pushCmd.Flags().StringVarP(&installationID, "installation-id", "i", "", "Give your installation an ID to keep it in the rotation")
 	pushCmd.Flags().BoolVarP(&background, "background", "b", false, "Don't immediately show the image on the device")
 }
 
@@ -45,8 +47,10 @@ var pushCmd = &cobra.Command{
 func push(cmd *cobra.Command, args []string) {
 	deviceID := args[0]
 	image := args[1]
-	installationID := ""
 
+	// TODO (mark): This is better served as a flag, but I don't want to break
+	// folks in the short term. We should consider dropping this as an arguement
+	// in a future release.
 	if len(args) == 3 {
 		installationID = args[2]
 	}


### PR DESCRIPTION
This commit moves the installationID to be supported through a flag instead of an argument to be consistent with the background flag. I left support for the argument in the short term so we don't break current workflows. We'll drop support for the argument in a future release.