### PR TITLE
Add Starlib HTML module to Pixlet runtime

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -11,6 +11,7 @@ import (
 	starlibjson "go.starlark.net/lib/json"
 	starlibmath "go.starlark.net/lib/math"
 	starlibtime "go.starlark.net/lib/time"
+	starlibhtml "github.com/qri-io/starlib/html"
 	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -200,6 +201,9 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 
 	case "http.star":
 		return starlibhttp.LoadModule()
+
+	case "html.star":
+		return starlibhtml.LoadModule()
 
 	case "math.star":
 		return starlark.StringDict{


### PR DESCRIPTION
I saw [this Feature Request ](https://discuss.tidbyt.com/t/including-the-html-module-in-pixlet/1435) asking for Starlark HTML module to be included in the runtime. It looks like a useful module to help with extracting/scraping data from web sources that may not have an API. It didn't seem to add much to the overall binary size so I figured it made sense to include it. 