### PR TITLE
Allow writing image data to stdout

### DIFF
--- a/render.go
+++ b/render.go
@@ -134,7 +134,12 @@ func render(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = ioutil.WriteFile(outPath, buf, 0644)
+    if outPath == "-" {
+        _, err = os.Stdout.Write(buf)
+    } else  {
+	    err = ioutil.WriteFile(outPath, buf, 0644)
+	}
+
 	if err != nil {
 		fmt.Printf("Writing %s: %s", outPath, err)
 		os.Exit(1)


### PR DESCRIPTION
This commit supports using the character `-` to specify writing image data to stdout, rather than a file. This allows piping the image data to another program - such as to view the image in the terminal directly (for terminals which support it).