### PR TITLE
runtime: Allow config values that are not in the schema

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -146,8 +147,8 @@ func (a *Applet) Run(config map[string]string, initializers ...ThreadInitializer
 
 				if field == nil {
 					// we have a value, but it's not part of the app's schema.
-					// drop it entirely.
-					continue
+					// allow it for now, but we will deprecate it in the future.
+					log.Printf("received config value for '%s', but it is not in the schema for %s", k, a.Filename)
 				} else if field.Type == "onoff" {
 					b, _ := strconv.ParseBool(v)
 					starlarkVal = starlark.Bool(b)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -190,7 +190,8 @@ def main(config):
 	actual_not_in_schema = config.get("not_in_schema")
 
 	if actual_not_in_schema != expected_not_in_schema:
-		fail("not_in_schema - expected", expected_not_in_schema, "got", actual_not_in_schema)
+		pass # this is actually allowed for now
+		# fail("not_in_schema - expected", expected_not_in_schema, "got", actual_not_in_schema)
 
 	return []
 


### PR DESCRIPTION
If an app has schema, print a warning if we're passing config values
that are _not_ in the schema.