### PR TITLE
Move secrets from schema to separate module

### DIFF
--- a/runtime/secret.go
+++ b/runtime/secret.go
@@ -3,12 +3,20 @@ package runtime
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/google/tink/go/hybrid"
 	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/tink"
 	"github.com/pkg/errors"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+const (
+	threadDecrypterKey = "tidbyt.dev/pixlet/runtime/decrypter"
 )
 
 // SecretDecryptionKey is a key that can be used to decrypt secrets.
@@ -25,43 +33,6 @@ type SecretDecryptionKey struct {
 type SecretEncryptionKey struct {
 	// PublicKeysetJSON is the serialized JSON representation of a Tink keyset.
 	PublicKeysetJSON []byte
-}
-
-func (sdk *SecretDecryptionKey) decrypt(a *Applet) error {
-	if a.schema == nil || len(a.schema.Secrets) == 0 {
-		// nothing to do
-		return nil
-	}
-
-	r := bytes.NewReader(sdk.EncryptedKeysetJSON)
-	kh, err := keyset.Read(keyset.NewJSONReader(r), sdk.KeyEncryptionKey)
-	if err != nil {
-		return errors.Wrap(err, "reading keyset JSON")
-	}
-
-	dec, err := hybrid.NewHybridDecrypt(kh)
-	if err != nil {
-		return errors.Wrap(err, "NewHybridDecrypt")
-	}
-
-	context := []byte(strings.TrimSuffix(a.Filename, ".star"))
-
-	a.decryptedSecrets = make(map[string]string, len(a.schema.Secrets))
-	for k, v := range a.schema.Secrets {
-		ciphertext, err := base64.StdEncoding.DecodeString(v)
-		if err != nil {
-			return errors.Wrapf(err, "base64 decoding of secret '%s'", k)
-		}
-
-		cleartext, err := dec.Decrypt(ciphertext, context)
-		if err != nil {
-			return errors.Wrapf(err, "decrypting secret '%s'", k)
-		}
-
-		a.decryptedSecrets[k] = string(cleartext)
-	}
-
-	return nil
 }
 
 // Encrypt encrypts a value for use as a secret in an app. Provide both a value
@@ -86,4 +57,89 @@ func (sek *SecretEncryptionKey) Encrypt(appName, plaintext string) (string, erro
 	}
 
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+var (
+	secretOnce   sync.Once
+	secretModule starlark.StringDict
+)
+
+func LoadSecretModule() (starlark.StringDict, error) {
+	secretOnce.Do(func() {
+		secretModule = starlark.StringDict{
+			"secret": &starlarkstruct.Module{
+				Name: "secret",
+				Members: starlark.StringDict{
+					"decrypt": starlark.NewBuiltin("decrypt", secretDecrypt),
+				},
+			},
+		}
+	})
+
+	return secretModule, nil
+}
+
+type decrypter func(starlark.String) (starlark.String, error)
+
+func (sdk *SecretDecryptionKey) decrypterForApp(a *Applet) (decrypter, error) {
+	r := bytes.NewReader(sdk.EncryptedKeysetJSON)
+	kh, err := keyset.Read(keyset.NewJSONReader(r), sdk.KeyEncryptionKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading keyset JSON")
+	}
+
+	dec, err := hybrid.NewHybridDecrypt(kh)
+	if err != nil {
+		return nil, errors.Wrap(err, "NewHybridDecrypt")
+	}
+
+	context := []byte(strings.TrimSuffix(a.Filename, ".star"))
+
+	return func(s starlark.String) (starlark.String, error) {
+		ciphertext, err := base64.StdEncoding.DecodeString(s.GoString())
+		if err != nil {
+			return "", errors.Wrapf(err, "base64 decoding of secret: %s", s)
+		}
+
+		cleartext, err := dec.Decrypt(ciphertext, context)
+		if err != nil {
+			return "", errors.Wrapf(err, "decrypting secret: %s", s)
+		}
+
+		return starlark.String(cleartext), nil
+	}, nil
+}
+
+func (d decrypter) attachToThread(t *starlark.Thread) {
+	t.SetLocal(threadDecrypterKey, d)
+}
+
+func decrypterForThread(t *starlark.Thread) decrypter {
+	d, ok := t.Local(threadDecrypterKey).(decrypter)
+	if ok {
+		return d
+	} else {
+		return nil
+	}
+}
+
+func secretDecrypt(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var encryptedVal starlark.String
+
+	if err := starlark.UnpackPositionalArgs(
+		"decrypt",
+		args, kwargs,
+		0, &encryptedVal,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for secret.decrypt: %v", err)
+	}
+
+	dec := decrypterForThread(thread)
+
+	if dec == nil {
+		// no decrypter configured
+		return starlark.None, nil
+	}
+
+	return dec(encryptedVal)
 }

--- a/runtime/secret_test.go
+++ b/runtime/secret_test.go
@@ -56,26 +56,80 @@ func TestSecretDecrypt(t *testing.T) {
 	src := fmt.Sprintf(`
 load("render.star", "render")
 load("schema.star", "schema")
+load("secret.star", "secret")
+
+EXPECTED_PLAINTEXT = "%s"
+ENCRYPTED = "%s"
+DECRYPTED = secret.decrypt(ENCRYPTED)
 
 def assert_eq(message, actual, expected):
 	if not expected == actual:
 		fail(message, "-", "expected", expected, "actual", actual)
 
-def main(config):
-	assert_eq("secret value", config.get("top_secret"), "%s")
+def main():
+	assert_eq("secret value", DECRYPTED, EXPECTED_PLAINTEXT)
 	return render.Root(child=render.Box())
-
-def get_schema():
-	return schema.Schema(
-		version = "1",
-		secrets = {
-			"top_secret": "%s",
-		},
-	)
 `, plaintext, encrypted)
 
 	app := &Applet{
 		SecretDecryptionKey: decryptionKey,
+	}
+
+	err = app.Load("test.star", []byte(src), nil)
+	require.NoError(t, err)
+
+	roots, err := app.Run(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(roots))
+}
+
+func TestSecretDoesntDecryptWithoutKey(t *testing.T) {
+	plaintext := "h4x0rrszZ!!"
+
+	// make a test decryption key
+	dummyKEK := &dummyAEAD{}
+	khPriv, err := keyset.NewHandle(hybrid.ECIESHKDFAES128CTRHMACSHA256KeyTemplate())
+	require.NoError(t, err)
+
+	privJSON := &bytes.Buffer{}
+	err = khPriv.Write(keyset.NewJSONWriter(privJSON), dummyKEK)
+	require.NoError(t, err)
+
+	// get the corresponding public key and serialize it
+	khPub, err := khPriv.Public()
+	require.NoError(t, err)
+
+	pubJSON := &bytes.Buffer{}
+	err = khPub.WriteWithNoSecrets(keyset.NewJSONWriter(pubJSON))
+	require.NoError(t, err)
+
+	// encrypt the secret
+	encrypted, err := (&SecretEncryptionKey{
+		PublicKeysetJSON: pubJSON.Bytes(),
+	}).Encrypt("test", plaintext)
+	require.NoError(t, err)
+	assert.NotEqual(t, encrypted, "")
+
+	src := fmt.Sprintf(`
+load("render.star", "render")
+load("schema.star", "schema")
+load("secret.star", "secret")
+
+EXPECTED_PLAINTEXT = "%s"
+ENCRYPTED = "%s"
+DECRYPTED = secret.decrypt(ENCRYPTED)
+
+def assert_eq(message, actual, expected):
+	if not expected == actual:
+		fail(message, "-", "expected", expected, "actual", actual)
+
+def main():
+	assert_eq("secret value", DECRYPTED, None)
+	return render.Root(child=render.Box())
+`, plaintext, encrypted)
+
+	app := &Applet{
+		SecretDecryptionKey: nil,
 	}
 
 	err = app.Load("test.star", []byte(src), nil)

--- a/schema/module_test.go
+++ b/schema/module_test.go
@@ -31,14 +31,10 @@ s = schema.Schema(
 			icon = "cloud",
 		),
 	],
-	secrets = {
-		"top_secret": "aDR4MHJ6ISEhIQ==",
-	},
 )
 
 assert(s.version == "1")
 assert(s.fields[0].name == "Display Weather")
-assert(s.secrets.keys() == ["top_secret"])
 
 def main():
 	return []

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -26,9 +26,8 @@ const (
 // Schema holds a configuration object for an applet. It holds a list of fileds
 // that are exported from an applet.
 type Schema struct {
-	Version string            `json:"version" validate:"required"`
-	Fields  []SchemaField     `json:"schema" validate:"dive"`
-	Secrets map[string]string `json:"secrets"`
+	Version string        `json:"version" validate:"required"`
+	Fields  []SchemaField `json:"schema" validate:"dive"`
 
 	Handlers map[string]SchemaHandler `json:"-"`
 }


### PR DESCRIPTION
Instead of declaring secrets in `get_schema`, the new interface is to
load the `secret.star` module and call `secret.decrypt()`:

```starlark
load("secret.star", "secret")

API_KEY = secret.decrypt("<encrypted string goes here>")
```

This allows secrets to be used anywhere in an app, including in the
`get_schema` function itself.