### PR TITLE
schema: Add most all of our fields

### DIFF
--- a/schema/datetime.go
+++ b/schema/datetime.go
@@ -1,0 +1,86 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type DateTime struct {
+	SchemaField
+}
+
+func newDateTime(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id   starlark.String
+		name starlark.String
+		desc starlark.String
+		icon starlark.String
+	)
+
+	if err := starlark.UnpackArgs(
+		"DateTime",
+		args, kwargs,
+		"id", &id,
+		"name", &name,
+		"desc", &desc,
+		"icon", &icon,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for DateTime: %s", err)
+	}
+
+	s := &DateTime{}
+	s.SchemaField.Type = "datetime"
+	s.ID = id.GoString()
+	s.Name = name.GoString()
+	s.Description = desc.GoString()
+	s.Icon = icon.GoString()
+
+	return s, nil
+}
+
+func (s *DateTime) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *DateTime) AttrNames() []string {
+	return []string{
+		"id", "name", "desc", "icon",
+	}
+}
+
+func (s *DateTime) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "id":
+		return starlark.String(s.ID), nil
+
+	case "name":
+		return starlark.String(s.Name), nil
+
+	case "desc":
+		return starlark.String(s.Description), nil
+
+	case "icon":
+		return starlark.String(s.Icon), nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (s *DateTime) String() string       { return "DateTime(...)" }
+func (s *DateTime) Type() string         { return "DateTime" }
+func (s *DateTime) Freeze()              {}
+func (s *DateTime) Truth() starlark.Bool { return true }
+
+func (s *DateTime) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/datetime_test.go
+++ b/schema/datetime_test.go
@@ -1,0 +1,41 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var dateTimeSource = `
+load("schema.star", "schema")
+
+def assert(success, message=None):
+    if not success:
+        fail(message or "assertion failed")
+
+t = schema.DateTime(
+	id = "event_name",
+	name = "Event Name",
+	desc = "The time of the event.",
+	icon = "cog",
+)
+
+assert(t.id == "event_name")
+assert(t.name == "Event Name")
+assert(t.desc == "The time of the event.")
+assert(t.icon == "cog")
+
+def main():
+	return []
+`
+
+func TestDateTime(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("date_time.star", []byte(dateTimeSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/schema/locationbased.go
+++ b/schema/locationbased.go
@@ -1,0 +1,94 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type LocationBased struct {
+	SchemaField
+	starlarkHandler *starlark.Function
+}
+
+func newLocationBased(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id      starlark.String
+		name    starlark.String
+		desc    starlark.String
+		icon    starlark.String
+		handler *starlark.Function
+	)
+
+	if err := starlark.UnpackArgs(
+		"LocationBased",
+		args, kwargs,
+		"id", &id,
+		"name", &name,
+		"desc", &desc,
+		"icon", &icon,
+		"handler", &handler,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for LocationBased: %s", err)
+	}
+
+	s := &LocationBased{}
+	s.SchemaField.Type = "locationbased"
+	s.ID = id.GoString()
+	s.Name = name.GoString()
+	s.Description = desc.GoString()
+	s.Icon = icon.GoString()
+	s.Handler = handler.Name()
+	s.starlarkHandler = handler
+
+	return s, nil
+}
+
+func (s *LocationBased) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *LocationBased) AttrNames() []string {
+	return []string{
+		"id", "name", "desc", "icon", "handler",
+	}
+}
+
+func (s *LocationBased) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "id":
+		return starlark.String(s.ID), nil
+
+	case "name":
+		return starlark.String(s.Name), nil
+
+	case "desc":
+		return starlark.String(s.Description), nil
+
+	case "icon":
+		return starlark.String(s.Icon), nil
+
+	case "handler":
+		return s.starlarkHandler, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (s *LocationBased) String() string       { return "LocationBased(...)" }
+func (s *LocationBased) Type() string         { return "LocationBased" }
+func (s *LocationBased) Freeze()              {}
+func (s *LocationBased) Truth() starlark.Bool { return true }
+
+func (s *LocationBased) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/locationbased_test.go
+++ b/schema/locationbased_test.go
@@ -1,0 +1,71 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var locationBasedSource = `
+load("encoding/json.star", "json")
+load("schema.star", "schema")
+
+DEFAULT_LOCATION = """
+{
+	"lat": "40.6781784",
+	"lng": "-73.9441579",
+	"description": "Brooklyn, NY, USA",
+	"locality": "Brooklyn",
+	"place_id": "ChIJCSF8lBZEwokRhngABHRcdoI",
+	"timezone": "America/New_York"
+}
+"""
+
+def assert(success, message = None):
+    if not success:
+        fail(message or "assertion failed")
+
+def get_stations(location):
+    loc = json.decode(location)
+    lat, lng = float(loc["lat"]), float(loc["lng"])
+
+    return [
+        schema.Option(
+            display = "Grand Central",
+            value = "abc123",
+        ),
+        schema.Option(
+            display = "Penn Station",
+            value = "xyz123",
+        ),
+    ]
+
+t = schema.LocationBased(
+    id = "station",
+    name = "Train Station",
+    desc = "A list of train stations based on a location.",
+    icon = "train",
+    handler = get_stations,
+)
+
+assert(t.id == "station")
+assert(t.name == "Train Station")
+assert(t.desc == "A list of train stations based on a location.")
+assert(t.icon == "train")
+assert(t.handler(DEFAULT_LOCATION)[0].display == "Grand Central")
+
+def main():
+    return []
+
+`
+
+func TestLocationBased(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("location_based.star", []byte(locationBasedSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/schema/module.go
+++ b/schema/module.go
@@ -33,6 +33,7 @@ func LoadModule() (starlark.StringDict, error) {
 					"LocationBased": starlark.NewBuiltin("LocationBased", newLocationBased),
 					"DateTime":      starlark.NewBuiltin("DateTime", newDateTime),
 					"OAuth2":        starlark.NewBuiltin("OAuth2", newOAuth2),
+					"Radio":         starlark.NewBuiltin("Radio", newRadio),
 				},
 			},
 		}

--- a/schema/module.go
+++ b/schema/module.go
@@ -32,6 +32,7 @@ func LoadModule() (starlark.StringDict, error) {
 					"Text":          starlark.NewBuiltin("Text", newText),
 					"LocationBased": starlark.NewBuiltin("LocationBased", newLocationBased),
 					"DateTime":      starlark.NewBuiltin("DateTime", newDateTime),
+					"OAuth2":        starlark.NewBuiltin("OAuth2", newOAuth2),
 				},
 			},
 		}

--- a/schema/module.go
+++ b/schema/module.go
@@ -31,6 +31,7 @@ func LoadModule() (starlark.StringDict, error) {
 					"Location":      starlark.NewBuiltin("Location", newLocation),
 					"Text":          starlark.NewBuiltin("Text", newText),
 					"LocationBased": starlark.NewBuiltin("LocationBased", newLocationBased),
+					"DateTime":      starlark.NewBuiltin("DateTime", newDateTime),
 				},
 			},
 		}

--- a/schema/module.go
+++ b/schema/module.go
@@ -24,12 +24,13 @@ func LoadModule() (starlark.StringDict, error) {
 			ModuleName: &starlarkstruct.Module{
 				Name: ModuleName,
 				Members: starlark.StringDict{
-					"Schema":   starlark.NewBuiltin("Schema", newSchema),
-					"Toggle":   starlark.NewBuiltin("Toggle", newToggle),
-					"Option":   starlark.NewBuiltin("Option", newOption),
-					"Dropdown": starlark.NewBuiltin("Dropdown", newDropdown),
-					"Location": starlark.NewBuiltin("Location", newLocation),
-					"Text":     starlark.NewBuiltin("Text", newText),
+					"Schema":        starlark.NewBuiltin("Schema", newSchema),
+					"Toggle":        starlark.NewBuiltin("Toggle", newToggle),
+					"Option":        starlark.NewBuiltin("Option", newOption),
+					"Dropdown":      starlark.NewBuiltin("Dropdown", newDropdown),
+					"Location":      starlark.NewBuiltin("Location", newLocation),
+					"Text":          starlark.NewBuiltin("Text", newText),
+					"LocationBased": starlark.NewBuiltin("LocationBased", newLocationBased),
 				},
 			},
 		}

--- a/schema/module.go
+++ b/schema/module.go
@@ -35,6 +35,7 @@ func LoadModule() (starlark.StringDict, error) {
 					"OAuth2":        starlark.NewBuiltin("OAuth2", newOAuth2),
 					"Radio":         starlark.NewBuiltin("Radio", newRadio),
 					"PhotoSelect":   starlark.NewBuiltin("PhotoSelect", newPhotoSelect),
+					"Typeahead":     starlark.NewBuiltin("Typeahead", newTypeahead),
 				},
 			},
 		}

--- a/schema/module.go
+++ b/schema/module.go
@@ -34,6 +34,7 @@ func LoadModule() (starlark.StringDict, error) {
 					"DateTime":      starlark.NewBuiltin("DateTime", newDateTime),
 					"OAuth2":        starlark.NewBuiltin("OAuth2", newOAuth2),
 					"Radio":         starlark.NewBuiltin("Radio", newRadio),
+					"PhotoSelect":   starlark.NewBuiltin("PhotoSelect", newPhotoSelect),
 				},
 			},
 		}

--- a/schema/oauth2.go
+++ b/schema/oauth2.go
@@ -1,0 +1,136 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type OAuth2 struct {
+	SchemaField
+	starlarkHandler *starlark.Function
+	starlarkScopes  *starlark.List
+}
+
+func newOAuth2(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id           starlark.String
+		name         starlark.String
+		desc         starlark.String
+		icon         starlark.String
+		handler      *starlark.Function
+		clientID     starlark.String
+		authEndpoint starlark.String
+		scopes       *starlark.List
+	)
+
+	if err := starlark.UnpackArgs(
+		"OAuth2",
+		args, kwargs,
+		"id", &id,
+		"name", &name,
+		"desc", &desc,
+		"icon", &icon,
+		"handler", &handler,
+		"client_id", &clientID,
+		"authorization_endpoint", &authEndpoint,
+		"scopes", &scopes,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for OAuth2: %s", err)
+	}
+
+	s := &OAuth2{}
+	s.SchemaField.Type = "oauth2"
+	s.ID = id.GoString()
+	s.Name = name.GoString()
+	s.Description = desc.GoString()
+	s.Icon = icon.GoString()
+	s.Handler = handler.Name()
+	s.starlarkHandler = handler
+	s.ClientID = clientID.GoString()
+	s.AuthorizationEndpoint = authEndpoint.GoString()
+	s.starlarkScopes = scopes
+
+	if s.starlarkScopes != nil {
+		scopesIter := s.starlarkScopes.Iterate()
+		defer scopesIter.Done()
+
+		var scopeVal starlark.Value
+		for i := 0; scopesIter.Next(&scopeVal); {
+			if _, isNone := scopeVal.(starlark.NoneType); isNone {
+				continue
+			}
+
+			scope, ok := scopeVal.(starlark.String)
+			if !ok {
+				return nil, fmt.Errorf(
+					"expected fields to be a list of string but found: %s (at index %d)",
+					scopeVal.Type(),
+					i,
+				)
+			}
+
+			s.Scopes = append(s.Scopes, scope.GoString())
+		}
+	}
+
+	return s, nil
+}
+
+func (s *OAuth2) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *OAuth2) AttrNames() []string {
+	return []string{
+		"id", "name", "desc", "icon", "handler", "client_id", "authorization_endpoint", "scopes",
+	}
+}
+
+func (s *OAuth2) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "id":
+		return starlark.String(s.ID), nil
+
+	case "name":
+		return starlark.String(s.Name), nil
+
+	case "desc":
+		return starlark.String(s.Description), nil
+
+	case "icon":
+		return starlark.String(s.Icon), nil
+
+	case "handler":
+		return s.starlarkHandler, nil
+
+	case "client_id":
+		return starlark.String(s.ClientID), nil
+
+	case "authorization_endpoint":
+		return starlark.String(s.AuthorizationEndpoint), nil
+
+	case "scopes":
+		return s.starlarkScopes, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (s *OAuth2) String() string       { return "OAuth2(...)" }
+func (s *OAuth2) Type() string         { return "OAuth2" }
+func (s *OAuth2) Freeze()              {}
+func (s *OAuth2) Truth() starlark.Bool { return true }
+
+func (s *OAuth2) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/oauth2_test.go
+++ b/schema/oauth2_test.go
@@ -1,0 +1,57 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var oauth2Source = `
+load("encoding/json.star", "json")
+load("schema.star", "schema")
+
+def assert(success, message = None):
+    if not success:
+        fail(message or "assertion failed")
+
+def oauth_handler(params):
+    params = json.decode(params)
+    return "foobar123"
+
+t = schema.OAuth2(
+    id = "auth",
+    name = "GitHub",
+    desc = "Connect your GitHub account.",
+    icon = "github",
+    handler = oauth_handler,
+    client_id = "the-oauth2-client-id",
+    authorization_endpoint = "https://example.com/",
+    scopes = [
+        "read:user",
+    ],
+)
+
+assert(t.id == "auth")
+assert(t.name == "GitHub")
+assert(t.desc == "Connect your GitHub account.")
+assert(t.icon == "github")
+assert(t.handler("{}") == "foobar123")
+assert(t.client_id == "the-oauth2-client-id")
+assert(t.authorization_endpoint == "https://example.com/")
+assert(t.scopes == ["read:user"])
+
+def main():
+    return []
+
+`
+
+func TestOAuth2(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("oauth2.star", []byte(oauth2Source), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/schema/photoselect.go
+++ b/schema/photoselect.go
@@ -1,0 +1,86 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type PhotoSelect struct {
+	SchemaField
+}
+
+func newPhotoSelect(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id   starlark.String
+		name starlark.String
+		desc starlark.String
+		icon starlark.String
+	)
+
+	if err := starlark.UnpackArgs(
+		"PhotoSelect",
+		args, kwargs,
+		"id", &id,
+		"name", &name,
+		"desc", &desc,
+		"icon", &icon,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for PhotoSelect: %s", err)
+	}
+
+	s := &PhotoSelect{}
+	s.SchemaField.Type = "png"
+	s.ID = id.GoString()
+	s.Name = name.GoString()
+	s.Description = desc.GoString()
+	s.Icon = icon.GoString()
+
+	return s, nil
+}
+
+func (s *PhotoSelect) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *PhotoSelect) AttrNames() []string {
+	return []string{
+		"id", "name", "desc", "icon",
+	}
+}
+
+func (s *PhotoSelect) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "id":
+		return starlark.String(s.ID), nil
+
+	case "name":
+		return starlark.String(s.Name), nil
+
+	case "desc":
+		return starlark.String(s.Description), nil
+
+	case "icon":
+		return starlark.String(s.Icon), nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (s *PhotoSelect) String() string       { return "PhotoSelect(...)" }
+func (s *PhotoSelect) Type() string         { return "PhotoSelect" }
+func (s *PhotoSelect) Freeze()              {}
+func (s *PhotoSelect) Truth() starlark.Bool { return true }
+
+func (s *PhotoSelect) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/photoselect_test.go
+++ b/schema/photoselect_test.go
@@ -1,0 +1,41 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var photoSelectSource = `
+load("schema.star", "schema")
+
+def assert(success, message=None):
+    if not success:
+        fail(message or "assertion failed")
+
+t = schema.PhotoSelect(
+	id = "photo",
+	name = "Add Photo",
+	desc = "A photo.",
+	icon = "cog",
+)
+
+assert(t.id == "photo")
+assert(t.name == "Add Photo")
+assert(t.desc == "A photo.")
+assert(t.icon == "cog")
+
+def main():
+	return []
+`
+
+func TestPhotoSelect(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("photo_select.star", []byte(photoSelectSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/schema/radio.go
+++ b/schema/radio.go
@@ -1,0 +1,119 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type Radio struct {
+	SchemaField
+	starlarkOptions *starlark.List
+}
+
+func newRadio(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id      starlark.String
+		name    starlark.String
+		desc    starlark.String
+		icon    starlark.String
+		def     starlark.String
+		options *starlark.List
+	)
+
+	if err := starlark.UnpackArgs(
+		"Radio",
+		args, kwargs,
+		"id", &id,
+		"name", &name,
+		"desc", &desc,
+		"icon", &icon,
+		"default", &def,
+		"options", &options,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for Radio: %s", err)
+	}
+
+	s := &Radio{}
+	s.SchemaField.Type = "radio"
+	s.ID = id.GoString()
+	s.Name = name.GoString()
+	s.Description = desc.GoString()
+	s.Icon = icon.GoString()
+	s.Default = def.GoString()
+
+	var optionVal starlark.Value
+	optionIter := options.Iterate()
+	defer optionIter.Done()
+	for i := 0; optionIter.Next(&optionVal); {
+		if _, isNone := optionVal.(starlark.NoneType); isNone {
+			continue
+		}
+
+		o, ok := optionVal.(*Option)
+		if !ok {
+			return nil, fmt.Errorf(
+				"expected options to be a list of Option but found: %s (at index %d)",
+				optionVal.Type(),
+				i,
+			)
+		}
+
+		s.Options = append(s.Options, o.SchemaOption)
+	}
+	s.starlarkOptions = options
+
+	return s, nil
+}
+
+func (s *Radio) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *Radio) AttrNames() []string {
+	return []string{
+		"id", "name", "desc", "icon", "default", "options",
+	}
+}
+
+func (s *Radio) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "id":
+		return starlark.String(s.ID), nil
+
+	case "name":
+		return starlark.String(s.Name), nil
+
+	case "desc":
+		return starlark.String(s.Description), nil
+
+	case "icon":
+		return starlark.String(s.Icon), nil
+
+	case "default":
+		return starlark.String(s.Default), nil
+
+	case "options":
+		return s.starlarkOptions, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (s *Radio) String() string       { return "Radio(...)" }
+func (s *Radio) Type() string         { return "Radio" }
+func (s *Radio) Freeze()              {}
+func (s *Radio) Truth() starlark.Bool { return true }
+
+func (s *Radio) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/radio_test.go
+++ b/schema/radio_test.go
@@ -1,0 +1,61 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var radioSource = `
+load("schema.star", "schema")
+
+def assert(success, message=None):
+    if not success:
+        fail(message or "assertion failed")
+
+options = [
+	schema.Option(
+		display = "Green",
+		value = "#00FF00",
+	),
+	schema.Option(
+		display = "Red",
+		value = "#FF0000",
+	),
+]
+	
+s = schema.Radio(
+	id = "colors",
+	name = "Text Color",
+	desc = "The color of text to be displayed.", 
+	icon = "brush",
+	default = options[0].value,
+	options = options,
+)
+
+assert(s.id == "colors")
+assert(s.name == "Text Color")
+assert(s.desc == "The color of text to be displayed.")
+assert(s.icon == "brush")
+assert(s.default == "#00FF00")
+
+assert(s.options[0].display == "Green")
+assert(s.options[0].value == "#00FF00")
+
+assert(s.options[1].display == "Red")
+assert(s.options[1].value == "#FF0000")
+
+def main():
+	return []
+`
+
+func TestRadio(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("radio.star", []byte(radioSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -89,6 +89,9 @@ func FromStarlark(
 	starlarkSchema, ok := val.(*StarlarkSchema)
 	if ok {
 		schema = &starlarkSchema.Schema
+		if schema.Handlers == nil {
+			schema.Handlers = make(map[string]SchemaHandler)
+		}
 	} else {
 		schemaTree, err := unmarshalStarlark(val)
 		if err != nil {

--- a/schema/text.go
+++ b/schema/text.go
@@ -22,6 +22,7 @@ func newText(
 		name starlark.String
 		desc starlark.String
 		icon starlark.String
+		def  starlark.String
 	)
 
 	if err := starlark.UnpackArgs(
@@ -31,6 +32,7 @@ func newText(
 		"name", &name,
 		"desc", &desc,
 		"icon", &icon,
+		"default?", &def,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Text: %s", err)
 	}
@@ -41,6 +43,7 @@ func newText(
 	s.Name = name.GoString()
 	s.Description = desc.GoString()
 	s.Icon = icon.GoString()
+	s.Default = def.GoString()
 
 	return s, nil
 }
@@ -51,7 +54,7 @@ func (s *Text) AsSchemaField() SchemaField {
 
 func (s *Text) AttrNames() []string {
 	return []string{
-		"id", "name", "desc", "icon",
+		"id", "name", "desc", "icon", "default",
 	}
 }
 
@@ -69,6 +72,9 @@ func (s *Text) Attr(name string) (starlark.Value, error) {
 
 	case "icon":
 		return starlark.String(s.Icon), nil
+
+	case "default":
+		return starlark.String(s.Default), nil
 
 	default:
 		return nil, nil

--- a/schema/text_test.go
+++ b/schema/text_test.go
@@ -19,12 +19,14 @@ s = schema.Text(
 	name = "Screen Name",
 	desc = "A text entry for your screen name.",
 	icon = "user",
+	default = "foo",
 )
 
 assert(s.id == "screen_name")
 assert(s.name == "Screen Name")
 assert(s.desc == "A text entry for your screen name.")
 assert(s.icon == "user")
+assert(s.default == "foo")
 
 def main():
 	return []

--- a/schema/typeahead.go
+++ b/schema/typeahead.go
@@ -1,0 +1,94 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type Typeahead struct {
+	SchemaField
+	starlarkHandler *starlark.Function
+}
+
+func newTypeahead(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id      starlark.String
+		name    starlark.String
+		desc    starlark.String
+		icon    starlark.String
+		handler *starlark.Function
+	)
+
+	if err := starlark.UnpackArgs(
+		"Typeahead",
+		args, kwargs,
+		"id", &id,
+		"name", &name,
+		"desc", &desc,
+		"icon", &icon,
+		"handler", &handler,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for Typeahead: %s", err)
+	}
+
+	s := &Typeahead{}
+	s.SchemaField.Type = "typeahead"
+	s.ID = id.GoString()
+	s.Name = name.GoString()
+	s.Description = desc.GoString()
+	s.Icon = icon.GoString()
+	s.Handler = handler.Name()
+	s.starlarkHandler = handler
+
+	return s, nil
+}
+
+func (s *Typeahead) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *Typeahead) AttrNames() []string {
+	return []string{
+		"id", "name", "desc", "icon", "handler",
+	}
+}
+
+func (s *Typeahead) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "id":
+		return starlark.String(s.ID), nil
+
+	case "name":
+		return starlark.String(s.Name), nil
+
+	case "desc":
+		return starlark.String(s.Description), nil
+
+	case "icon":
+		return starlark.String(s.Icon), nil
+
+	case "handler":
+		return s.starlarkHandler, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func (s *Typeahead) String() string       { return "Typeahead(...)" }
+func (s *Typeahead) Type() string         { return "Typeahead" }
+func (s *Typeahead) Freeze()              {}
+func (s *Typeahead) Truth() starlark.Bool { return true }
+
+func (s *Typeahead) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/typeahead_test.go
+++ b/schema/typeahead_test.go
@@ -1,0 +1,56 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var typeaheadSource = `
+load("schema.star", "schema")
+
+def assert(success, message = None):
+    if not success:
+        fail(message or "assertion failed")
+
+def search(pattern):
+    return [
+        schema.Option(
+            display = "Grand Central",
+            value = "abc123",
+        ),
+        schema.Option(
+            display = "Penn Station",
+            value = "xyz123",
+        ),
+    ]
+
+t = schema.Typeahead(
+    id = "search",
+    name = "Search",
+    desc = "A list of items that match search.",
+    icon = "cog",
+    handler = search,
+)
+
+assert(t.id == "search")
+assert(t.name == "Search")
+assert(t.desc == "A list of items that match search.")
+assert(t.icon == "cog")
+assert(t.handler("")[0].display == "Grand Central")
+
+def main():
+    return []
+
+`
+
+func TestTypeahead(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("typeahead.star", []byte(typeaheadSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}


### PR DESCRIPTION
# Overview
We have a legacy format that we use internally that we decided to replace when open-sourcing schema. We're still bound by the original schema format because it's baked into the mobile app. This change takes almost all of our fields and make them publicly available. 

# Next Steps
- We have a field called `generated` that needs to be added here. It's going to take a bit more work and I wanted to publish what I have so far.
- Visibility. We have the ability to control if a field is visible or not depending on the state of other schema. It has not been cleaned up and introduced using the new schema format and I still need to do that.
- Docs. None of these fields have been documented yet. I think I should take my time and really work hard on making documentation for these fields awesome - so I will make that as part of a separate change.

# Changes
- schema: Add LocationBased. 
    - This commit adds support for LocationBased.
- schema: Add DateTime. 
    - This commit adds DateTime to the schema fields.
- schema: Add OAuth2.
    - This commit adds our OAuth2 schema field.
- schema: Add Radio.
    - This commit adds the Radio schema type.
- schema: Add PhotoSelect. 
    - This commit adds support for the PhotoSelect field.
- schema: Add Typeahead.
    - This commit adds typeahead.
- schema: Allow optional defaults in Text. 
    - This commit allows an optional default in Text.
- schema: Add test for schema parsing. 
    - This commit copies our existing test for the legacy schema format and ensures schema continues to parse as expected no matter the syntax.
    
# Tests
Every field has a test to ensure we can create an object in starlark and reference the values of the schema field later on that same object. This ensures the wiring from starlark -> go -> starlark works as expected. In addition, I've duplicated the test for all schema fields. This test ensures the wiring from starlark -> go -> json works as expected so that the mobile app will still be happy with these fields.