### PR TITLE
server: Propagate errors.

### DIFF
--- a/server/browser/preview.html
+++ b/server/browser/preview.html
@@ -22,6 +22,9 @@
 	<div style="border: solid 1px white">
 		<img id="render" src="data:image/webp;base64,{{ .WebP }}" />
 	</div>
+	<div>
+		<p id="errors" style="color: red;">{{ .Err }}</p>
+	</div>
 
 	{{ if .Watch }}
 	<script>
@@ -45,11 +48,19 @@
 			process(e) {
 				console.log("recieved new message");
 				const data = JSON.parse(e.data);
+				const img = document.getElementById("render");
+				const err = document.getElementById("errors");
 
 				switch (data.type) {
 					case "webp":
-						const img = document.getElementById("render");
 						img.src = "data:image/webp;base64," + data.message;
+						err.innerHTML = "";
+						break;
+					case "error":
+						err.innerHTML = data.message;
+						break;
+					default:
+						console.log(`unknown type ${data.type}`);
 				}
 			}
 

--- a/server/fanout/event.go
+++ b/server/fanout/event.go
@@ -4,6 +4,10 @@ const (
 	// EventTypeWebP is used to signal what type of message we are sending over
 	// the socket.
 	EventTypeWebP = "webp"
+
+	// EventTypeErr is used to signal there was an error encountered rendering
+	// the WebP image.
+	EventTypeErr = "error"
 )
 
 // WebsocketEvent is a structure used to send messages over the socket.

--- a/server/fanout/fanout.go
+++ b/server/fanout/fanout.go
@@ -3,7 +3,7 @@ package fanout
 // Fanout provides a structure for broadcasting messages to registered clients
 // when an update comes in on a go channel.
 type Fanout struct {
-	broadcast  chan string
+	broadcast  chan WebsocketEvent
 	quit       chan bool
 	register   chan *Client
 	unregister chan *Client
@@ -12,7 +12,7 @@ type Fanout struct {
 // NewFanout creates a new Fanout structure and runs the main loop.
 func NewFanout() *Fanout {
 	fo := &Fanout{
-		broadcast:  make(chan string, channelSize),
+		broadcast:  make(chan WebsocketEvent, channelSize),
 		register:   make(chan *Client, channelSize),
 		unregister: make(chan *Client, channelSize),
 		quit:       make(chan bool, 1),
@@ -24,8 +24,8 @@ func NewFanout() *Fanout {
 }
 
 // Broadcast sends a message to all registered clients.
-func (fo *Fanout) Broadcast(msg string) {
-	fo.broadcast <- msg
+func (fo *Fanout) Broadcast(event WebsocketEvent) {
+	fo.broadcast <- event
 }
 
 // RegisterClient registers a client to include in broadcasts.

--- a/server/server.go
+++ b/server/server.go
@@ -23,8 +23,11 @@ func NewServer(host string, port int, watch bool, filename string) (*Server, err
 	fileChanges := make(chan bool, 100)
 	w := watcher.NewWatcher(filename, fileChanges)
 
-	updatesChan := make(chan string, 100)
-	l := loader.NewLoader(filename, watch, fileChanges, updatesChan)
+	updatesChan := make(chan loader.Update, 100)
+	l, err := loader.NewLoader(filename, watch, fileChanges, updatesChan)
+	if err != nil {
+		return nil, err
+	}
 
 	addr := fmt.Sprintf("%s:%d", host, port)
 	b, err := browser.NewBrowser(addr, filename, watch, updatesChan, l)


### PR DESCRIPTION
# Overview
There is a panic when you run `pixlet serve --watch` on a broken app. It was driving me bananas! In addition, a fix was that I had to fix the app and then restart the server??? This change fixes all of that. Now, you only have to run `pixlet serve --watch` once and it will propagate all errors to the browser. Note - this is pretty ugly and basic right now. I'm working on an overhauled devtools experience and should have it shortly.

# Changes
- server: Propagate errors.
    - This commit fixes a panic when there is an error on `pixlet serve` both for the case of `--watch` and the case without watching. In addition, it propagates any and all errors to the preview window so an engineer always knows when something is broken.
    
# Example
![Screen Shot 2022-02-02 at 5 54 53 PM](https://user-images.githubusercontent.com/3886576/152253237-f62e59db-808c-4239-9d8d-ba8a98e2e2ff.png)

