### PR TITLE
add max_age to Root widget

### DIFF
--- a/encode/encode.go
+++ b/encode/encode.go
@@ -19,7 +19,7 @@ const (
 	WebPKMin                 = 0
 	WebPKMax                 = 0
 	DefaultScreenDelayMillis = 50
-	DefaultMaxAgeSeconds     = 0
+	DefaultMaxAgeSeconds     = 0 // 0 => no max age, cache forever!
 )
 
 type Screens struct {

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -65,9 +65,11 @@ func (s *Screens) Hash() ([]byte, error) {
 		Roots  []render.Root
 		Images []image.Image
 		Delay  int32
+		MaxAge int32
 	}{
-		Roots: s.roots,
-		Delay: s.delay,
+		Roots:  s.roots,
+		Delay:  s.delay,
+		MaxAge: s.MaxAge,
 	}
 
 	if len(s.roots) == 0 {

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -19,24 +19,30 @@ const (
 	WebPKMin                 = 0
 	WebPKMax                 = 0
 	DefaultScreenDelayMillis = 50
+	DefaultMaxAgeSeconds     = 0
 )
 
 type Screens struct {
 	roots  []render.Root
 	images []image.Image
 	delay  int32
+	MaxAge int32
 }
 
 type ImageFilter func(image.Image) (image.Image, error)
 
 func ScreensFromRoots(roots []render.Root) *Screens {
 	screens := Screens{
-		roots: roots,
-		delay: DefaultScreenDelayMillis,
+		roots:  roots,
+		delay:  DefaultScreenDelayMillis,
+		MaxAge: DefaultMaxAgeSeconds,
 	}
 	if len(roots) > 0 {
 		if roots[0].Delay > 0 {
 			screens.delay = roots[0].Delay
+		}
+		if roots[0].MaxAge > 0 {
+			screens.MaxAge = roots[0].MaxAge
 		}
 	}
 	return &screens
@@ -46,6 +52,7 @@ func ScreensFromImages(images ...image.Image) *Screens {
 	screens := Screens{
 		images: images,
 		delay:  DefaultScreenDelayMillis,
+		MaxAge: DefaultMaxAgeSeconds,
 	}
 	return &screens
 }

--- a/encode/encode_test.go
+++ b/encode/encode_test.go
@@ -166,6 +166,22 @@ func TestHash(t *testing.T) {
 	require.NotEqual(t, hash, hash2)
 }
 
+func TestHashDelayAndMaxAge(t *testing.T) {
+	r := []render.Root{render.Root{Child: &render.Text{Content: "derp"}}}
+
+	h1, err := ScreensFromRoots(r).Hash()
+	assert.NoError(t, err)
+	r[0].MaxAge = 12
+	h2, err := ScreensFromRoots(r).Hash()
+	assert.NoError(t, err)
+	r[0].Delay = 1
+	h3, err := ScreensFromRoots(r).Hash()
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, h1, h2)
+	assert.NotEqual(t, h2, h3)
+}
+
 func TestScreensFromRoots(t *testing.T) {
 	// check that widget trees and params are copied correctly
 	s := ScreensFromRoots([]render.Root{

--- a/encode/encode_test.go
+++ b/encode/encode_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"tidbyt.dev/pixlet/render"
 	"tidbyt.dev/pixlet/runtime"
 )
 
@@ -163,4 +164,27 @@ func TestHash(t *testing.T) {
 
 	// ensure hashes are different
 	require.NotEqual(t, hash, hash2)
+}
+
+func TestScreensFromRoots(t *testing.T) {
+	// check that widget trees and params are copied correctly
+	s := ScreensFromRoots([]render.Root{
+		render.Root{Child: &render.Text{Content: "tree 0"}},
+		render.Root{Child: &render.Text{Content: "tree 1"}},
+	})
+	assert.Equal(t, 2, len(s.roots))
+	assert.Equal(t, "tree 0", s.roots[0].Child.(*render.Text).Content)
+	assert.Equal(t, "tree 1", s.roots[1].Child.(*render.Text).Content)
+	assert.Equal(t, 0, len(s.images))
+	assert.Equal(t, int32(50), s.delay)
+	assert.Equal(t, int32(0), s.MaxAge)
+
+	// check that delay and maxAge are copied from first root only
+	s = ScreensFromRoots([]render.Root{
+		render.Root{Child: &render.Text{Content: "tree 0"}, Delay: 4711, MaxAge: 42},
+		render.Root{Child: &render.Text{Content: "tree 1"}, Delay: 31415, MaxAge: 926535},
+	})
+	assert.Equal(t, 2, len(s.roots))
+	assert.Equal(t, int32(4711), s.delay)
+	assert.Equal(t, int32(42), s.MaxAge)
 }

--- a/render/root.go
+++ b/render/root.go
@@ -24,9 +24,15 @@ const (
 //
 // If the tree contains animated widgets, the resulting animation will
 // run with _delay_ milliseconds per frame.
+//
+// If the tree holds time sensitive information which must never be
+// displayed past a certain point in time, pass _MaxAge_ to specify
+// an expiration time in seconds. Display devices use this to avoid
+// displaying stale data in the event of e.g. connectivity issues.
 type Root struct {
-	Child Widget
-	Delay int32
+	Child  Widget
+	Delay  int32
+	MaxAge int32
 }
 
 // Paint renders the child widget onto the frame. It doesn't do

--- a/runtime/frame.go
+++ b/runtime/frame.go
@@ -11,28 +11,33 @@ import (
 
 type Root struct {
 	render.Root
-	starlarkChild starlark.Value
-	starlarkDelay starlark.Int
+	starlarkChild  starlark.Value
+	starlarkDelay  starlark.Int
+	starlarkMaxAge starlark.Int
 }
 
 func newRoot(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var child starlark.Value
 	var delay starlark.Int
+	var maxAge starlark.Int
 
 	if err := starlark.UnpackArgs(
 		"Root",
 		args, kwargs,
 		"child", &child,
 		"delay?", &delay,
+		"max_age?", &maxAge,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Root: %s", err)
 	}
 
 	r := Root{
-		starlarkChild: child,
-		starlarkDelay: delay,
+		starlarkChild:  child,
+		starlarkDelay:  delay,
+		starlarkMaxAge: maxAge,
 	}
 	r.Delay = int32(delay.BigInt().Int64())
+	r.MaxAge = int32(maxAge.BigInt().Int64())
 
 	w, ok := child.(Widget)
 	if !ok {
@@ -51,6 +56,7 @@ func (r Root) AttrNames() []string {
 	return []string{
 		"child",
 		"delay",
+		"max_age",
 	}
 }
 
@@ -61,6 +67,9 @@ func (r Root) Attr(name string) (starlark.Value, error) {
 
 	case "delay":
 		return r.starlarkDelay, nil
+
+	case "max_age":
+		return r.starlarkMaxAge, nil
 
 	default:
 		return nil, nil


### PR DESCRIPTION
When a Tidbyt device fails to receive new screen data for an
installation - e.g. due to a connectivity issue, or a bug in an
applet - it will keep displaying the most recently received graphic.
That's not a desirable behavior for something like a clock, where
stale data could cause someone to be late for a meeting, or get
out of bed earlier than needed. The horror.

The max_age attribute will be passed on to the Tidbyt device,
allowing it to expire stale screen data.