### PR TITLE
schema: Fix schema options.

### DIFF
--- a/schema/option.go
+++ b/schema/option.go
@@ -33,6 +33,7 @@ func newOption(
 
 	s := &Option{}
 	s.SchemaOption.Text = display.GoString()
+	s.SchemaOption.Display = display.GoString()
 	s.SchemaOption.Value = value.GoString()
 
 	return s, nil

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -169,12 +169,14 @@ def main():
 				Description: "A Dropdown",
 				Options: []schema.SchemaOption{
 					{
-						Text:  "dt1",
-						Value: "dv1",
+						Display: "dt1",
+						Text:    "dt1",
+						Value:   "dv1",
 					},
 					{
-						Text:  "dt2",
-						Value: "dv2",
+						Display: "dt2",
+						Text:    "dt2",
+						Value:   "dv2",
 					},
 				},
 				Default: "dv2",
@@ -663,7 +665,7 @@ def main():
 
 	stringValue, err := app.CallSchemaHandler(context.Background(), "locationbasedid", "fart")
 	assert.NoError(t, err)
-	assert.Equal(t, "[{\"text\":\"Your only option is\",\"value\":\"fart\"}]", stringValue)
+	assert.Equal(t, "[{\"display\":\"\",\"text\":\"Your only option is\",\"value\":\"fart\"}]", stringValue)
 }
 
 func TestSchemaWithLocationBasedHandlerMalformed(t *testing.T) {
@@ -718,7 +720,7 @@ def main():
 
 	stringValue, err := app.CallSchemaHandler(context.Background(), "typeaheadid", "farts")
 	assert.NoError(t, err)
-	assert.Equal(t, "[{\"text\":\"You searched for\",\"value\":\"farts\"}]", stringValue)
+	assert.Equal(t, "[{\"display\":\"\",\"text\":\"You searched for\",\"value\":\"farts\"}]", stringValue)
 }
 
 func TestSchemaWithTypeaheadHandlerMalformed(t *testing.T) {


### PR DESCRIPTION
This commit fixes a few things with schema options that were wrong. I
renamed "text" to "display" since I found it more descriptive. The issue
is the object wasn't renamed when it was injected into config. In
addition, I didn't consider that we could get an "option" back from
schema handlers when I moved to the syntactic sugar version of schema.