### PR TITLE
serve: Fix cache.

### DIFF
--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -46,6 +46,8 @@ func NewLoader(filename string, watch bool, fileChanges chan bool, updatesChan c
 		resultsChan:      make(chan Update, 100),
 	}
 
+	runtime.InitCache(runtime.NewInMemoryCache())
+
 	if !l.watch {
 		err := loadScript(&l.applet, l.filename)
 		if err != nil {
@@ -138,8 +140,6 @@ func loadScript(applet *runtime.Applet, filename string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", filename, err)
 	}
-
-	runtime.InitCache(runtime.NewInMemoryCache())
 
 	err = applet.Load(filename, src, nil)
 	if err != nil {


### PR DESCRIPTION
# Overview
The `cache` module currently does not work with the `--watch` flag because we recreate it every time. This change ensures we only create it once so hot reloads still utilize the cache.

# Changes
- This commit resolves an issue where the cache gets recreated every time there is a change.

# Tests
I ran the bitcoin example and ensured the prints around the cache matched the expected case on reloads and changes:
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|main⚡ ⇒  make build
rm -f pixlet
rm -rf ./build
go build -o pixlet tidbyt.dev/pixlet
```
```
mark@dev-mark:~/code/src/tidbyt.dev/pixlet|main⚡ ⇒  ./pixlet serve examples/bitcoin.star --watch --port 3232
2022/02/04 15:47:31 listening at http://127.0.0.1:3232
[examples/bitcoin.star] Miss! Calling CoinDesk API.
2022/02/04 15:47:54 detected updates for examples/bitcoin.star, reloading
[examples/bitcoin.star] Hit! Displaying cached data.
2022/02/04 15:47:54 detected updates for examples/bitcoin.star, reloading
[examples/bitcoin.star] Hit! Displaying cached data.
[examples/bitcoin.star] Hit! Displaying cached data.
[examples/bitcoin.star] Hit! Displaying cached data.
```