### PR TITLE
schema: add generated field

### DIFF
--- a/schema/generated.go
+++ b/schema/generated.go
@@ -1,0 +1,80 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"go.starlark.net/starlark"
+)
+
+type Generated struct {
+	SchemaField
+	starlarkHandler *starlark.Function
+}
+
+func newGenerated(
+	thread *starlark.Thread,
+	_ *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var (
+		id      starlark.String
+		source  starlark.String
+		handler *starlark.Function
+	)
+
+	if err := starlark.UnpackArgs(
+		"Generated",
+		args, kwargs,
+		"source", &source,
+		"handler", &handler,
+		"id", &id,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for Generated: %s", err)
+	}
+
+	s := &Generated{}
+	s.starlarkHandler = handler
+	s.Source = source.GoString()
+	s.Handler = handler.Name()
+	s.ID = id.GoString()
+	s.SchemaField.Type = "generated"
+
+	return s, nil
+}
+
+func (s *Generated) AsSchemaField() SchemaField {
+	return s.SchemaField
+}
+
+func (s *Generated) AttrNames() []string {
+	return []string{
+		"source", "handler", "id",
+	}
+}
+
+func (s *Generated) Attr(name string) (starlark.Value, error) {
+	switch name {
+
+	case "source":
+		return starlark.String(s.Source), nil
+
+	case "handler":
+		return s.starlarkHandler, nil
+	case "id":
+		return starlark.String(s.ID), nil
+	default:
+		return nil, nil
+	}
+}
+
+func (s *Generated) String() string       { return "Generated(...)" }
+func (s *Generated) Type() string         { return "Generated" }
+func (s *Generated) Freeze()              {}
+func (s *Generated) Truth() starlark.Bool { return true }
+
+func (s *Generated) Hash() (uint32, error) {
+	sum, err := hashstructure.Hash(s, hashstructure.FormatV2, nil)
+	return uint32(sum), err
+}

--- a/schema/generated_test.go
+++ b/schema/generated_test.go
@@ -1,0 +1,39 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var generatedSource = `
+load("schema.star", "schema")
+
+def assert(success, message=None):
+    if not success:
+        fail(message or "assertion failed")
+
+s = schema.Generated(
+	id = "foo",
+        source = "bar",
+        handler = assert,
+)
+
+assert(s.id == "foo")
+assert(s.source == "bar")
+assert(s.handler == assert)
+
+def main():
+	return []
+`
+
+func TestGenerated(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("generated.star", []byte(generatedSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/schema/module.go
+++ b/schema/module.go
@@ -47,6 +47,7 @@ func LoadModule() (starlark.StringDict, error) {
 					"Typeahead":     starlark.NewBuiltin("Typeahead", newTypeahead),
 					"Handler":       starlark.NewBuiltin("Handler", newHandler),
 					"HandlerType":   handlerType,
+					"Generated":     starlark.NewBuiltin("Generated", newGenerated),
 				},
 			},
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -262,6 +262,8 @@ func unmarshalStarlark(object starlark.Value) (interface{}, error) {
 		return goMap, nil
 	case *Option:
 		return v.AsSchemaOption(), nil
+	case Field:
+		return v.AsSchemaField(), nil
 	}
 
 	return nil, fmt.Errorf("type %s not allowed in schema", object.Type())


### PR DESCRIPTION
The Generated field references a source field, and a handler. When
the source field value changes, the handler is called. The handler
in turn returns a Schema object, which can change dynamically as
the source field changes.