### PR TITLE
Add Windows build instructions.

### DIFF
--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -1,0 +1,45 @@
+Building Pixlet (on Windows)
+============================
+
+Prerequisites
+-------------
+
+- Having [MSYS2 installed].
+- Having [node installed].
+
+Steps
+-----
+- Start the [MINGW64 environment].
+- Install dependencies:
+	```console
+	pacman -S git
+	pacman -S mingw-w64-x86_64-go
+	pacman -S mingw-w64-x86_64-toolchain
+	pacman -S mingw-w64-x86_64-libwebp
+	```
+- Add `node` and `npm` to your path:
+	```console
+	export PATH=$PATH:/c/Program\ Files/nodejs
+	```
+- Clone the repository:
+	```console
+	git clone https://github.com/tidbyt/pixlet
+	```
+- Cd into the repository:
+	```console
+	cd pixlet
+	```
+- Build the frontend:
+	```console
+	npm install
+	npm run build
+	```
+- Build the binary:
+	```console
+	make build
+	```
+- After that you will have the binary `/pixlet.exe`, which you should copy to your path.
+
+[node installed]: https://nodejs.org/en/download/
+[MSYS2 installed]: https://www.msys2.org/#installation
+[MINGW64 environment]: https://www.msys2.org/docs/environments/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
+ifeq ($(OS),Windows_NT)
+	BINARY = pixlet.exe
+	LDFLAGS = -ldflags="-s -extldflags=-static"
+else
+	BINARY = pixlet
+endif
+
 test:
 	go test -v -cover ./...
 
 clean:
-	rm -f pixlet
+	rm -f $(BINARY)
 	rm -rf ./build
 	rm -rf ./out
 
@@ -10,7 +17,7 @@ bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
 
 build: clean
-	go build -o pixlet tidbyt.dev/pixlet
+	go build $(LDFLAGS) -o $(BINARY) tidbyt.dev/pixlet
 
 embedfonts:
 	go run render/gen/embedfonts.go

--- a/server/watcher/watcher.go
+++ b/server/watcher/watcher.go
@@ -18,7 +18,7 @@ type Watcher struct {
 // channel.
 func NewWatcher(filename string, fileChanges chan bool) *Watcher {
 	return &Watcher{
-		filename:    filename,
+		filename:    filepath.FromSlash(filename),
 		fileChanges: fileChanges,
 	}
 }


### PR DESCRIPTION
This PR adds instructions for how to build pixlet on Windows using [MSYS2](https://www.msys2.org/) / [MINGW64](https://www.msys2.org/docs/environments/).

I put the instructions in a separate `BUILD_WINDOWS.md` file, as to not clutter the main build instructions.

Additionally it fixes an issue with the watcher and mixed path separators, which can happen when running pixlet from an MSYS2 shell.