### PR TITLE
Add `hash` starlib module to pixlet runtime

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -30,6 +30,7 @@ individual modules, please refer to the Starlib documentation.
 | --- | --- |
 | [`encoding/base64.star`](https://github.com/qri-io/starlib/tree/master/encoding/base64) | Base 64 encoding and decoding |
 | [`encoding/json.star`](https://github.com/qri-io/starlib/tree/master/encoding/json) | JSON encoding and decoding |
+| [`hash.star`](https://github.com/qri-io/starlib/tree/master/hash) | MD5, SHA1, SHA256 hash generation  |
 | [`html.star`](https://github.com/qri-io/starlib/tree/master/html) | jQuery-like functions for HTML  |
 | [`http.star`](https://github.com/qri-io/starlib/tree/master/http) | HTTP client |
 | [`math.star`](https://github.com/qri-io/starlib/tree/master/math) | Mathematical functions and constants |

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	starlibbase64 "github.com/qri-io/starlib/encoding/base64"
+	starlibhash "github.com/qri-io/starlib/hash"
 	starlibhtml "github.com/qri-io/starlib/html"
 	starlibhttp "github.com/qri-io/starlib/http"
 	starlibre "github.com/qri-io/starlib/re"
@@ -304,6 +305,9 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 		return starlark.StringDict{
 			starlibjson.Module.Name: starlibjson.Module,
 		}, nil
+
+	case "hash.star":
+		return starlibhash.LoadModule()
 
 	case "http.star":
 		return starlibhttp.LoadModule()


### PR DESCRIPTION
Someone [mentioned](https://discuss.tidbyt.com/t/including-the-html-module-in-pixlet/1435/5?u=drudge) having to call out to a webservice to generate an MD5 hash.

This seems like another useful module to have in PIxlet's runtime.