### PR TITLE
Fix devtools UI breaking on fields with no icon

### DIFF
--- a/src/features/schema/FieldIcon.jsx
+++ b/src/features/schema/FieldIcon.jsx
@@ -9,6 +9,11 @@ import styles from './styles.css';
 
 export default function FieldIcon(props) {
     const iconName = props.icon;
+
+    if (!iconName) {
+        return null;
+    }
+
     const faIconName = iconName.replace(/[A-Z]/g, m => "-" + m.toLowerCase());
 
     let icoDef = findIconDefinition({ prefix: 'fas', iconName: faIconName });


### PR DESCRIPTION
This commit prevents the DevTools UI from crashing when it encounters a field that doesn't require/have an icon, like `schema.Generated`.