### PR TITLE
Add additional behaviors to Marquee widget.

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -183,14 +183,25 @@ The `scroll_direction` will be 'horizontal' and will scroll from right
 to left if left empty, if specified as 'vertical' the Marquee will
 scroll from bottom to top.
 
+The `behavior` will be 'scroll' and will scroll the child out of view
+and back into the view if left empty, if specified as 'alternate' the
+Marquee will scroll the child out of the view until it reaches its end,
+then switch directions.
+
 In horizontal mode the height of the Marquee will be that of its child,
 but its `width` must be specified explicitly. In vertical mode the width
 will be that of its child but the `height` must be specified explicitly.
 
-If the child's width fits fully, it will not scroll.
+If the child's width fits fully, it will only scroll if `scroll_always`
+is set.
 
 The `offset_start` and `offset_end` parameters control the position
 of the child in the beginning and the end of the animation.
+This is only supported if `behavior` is set to `scroll`.
+
+The `pause_start` and `pause_midway` parameters control the number of
+frames to pause at the beginning and at the midway point of the animation.
+This is only supported if `behavior` is set to `alternate`.
 
 #### Attributes
 | Name | Type | Description | Required |
@@ -200,7 +211,11 @@ of the child in the beginning and the end of the animation.
 | `height` | `int` | Height of the Marquee, required for vertical | N |
 | `offset_start` | `int` | Position of child at beginning of animation | N |
 | `offset_end` | `int` | Position of child at end of animation | N |
+| `behavior` | `str` | Behavior of scrolling, 'scroll' or 'alternate', default is scroll | N |
 | `scroll_direction` | `str` | Direction to scroll, 'vertical' or 'horizontal', default is horizontal | N |
+| `scroll_always` | `bool` | Scroll child, even if it fits entirely | N |
+| `pause_start` | `int` | Pause at beginning of animation, default and minumum is 1 | N |
+| `pause_midway` | `int` | Pause at midway point of animation, default and minumum is 1 | N |
 
 #### Example
 ```

--- a/render/marquee.go
+++ b/render/marquee.go
@@ -11,21 +11,36 @@ import (
 // to left if left empty, if specified as 'vertical' the Marquee will
 // scroll from bottom to top.
 //
+// The `behavior` will be 'scroll' and will scroll the child out of view
+// and back into the view if left empty, if specified as 'alternate' the
+// Marquee will scroll the child out of the view until it reaches its end,
+// then switch directions.
+//
 // In horizontal mode the height of the Marquee will be that of its child,
 // but its `width` must be specified explicitly. In vertical mode the width
 // will be that of its child but the `height` must be specified explicitly.
 //
-// If the child's width fits fully, it will not scroll.
+// If the child's width fits fully, it will only scroll if `scroll_always`
+// is set.
 //
 // The `offset_start` and `offset_end` parameters control the position
 // of the child in the beginning and the end of the animation.
+// This is only supported if `behavior` is set to `scroll`.
+//
+// The `pause_start` and `pause_midway` parameters control the number of
+// frames to pause at the beginning and at the midway point of the animation.
+// This is only supported if `behavior` is set to `alternate`.
 //
 // DOC(Child): Widget to potentially scroll
 // DOC(Width): Width of the Marquee, required for horizontal
 // DOC(Height): Height of the Marquee, required for vertical
+// DOC(Behavior): Behavior of scrolling, 'scroll' or 'alternate', default is scroll
 // DOC(OffsetStart): Position of child at beginning of animation
 // DOC(OffsetEnd): Position of child at end of animation
+// DOC(PauseStart): Pause at beginning of animation, default and minumum is 1
+// DOC(PauseMidway): Pause at midway point of animation, default and minumum is 1
 // DOC(ScrollDirection): Direction to scroll, 'vertical' or 'horizontal', default is horizontal
+// DOC(ScrollAlways): Scroll child, even if it fits entirely
 //
 // EXAMPLE BEGIN
 // render.Marquee(
@@ -42,7 +57,20 @@ type Marquee struct {
 	Height          int    `starlark:"height"`
 	OffsetStart     int    `starlark:"offset_start"`
 	OffsetEnd       int    `starlark:"offset_end"`
+	Behavior        string `starlark:"behavior"`
 	ScrollDirection string `starlark:"scroll_direction"`
+	ScrollAlways    bool   `starlark:"scroll_always"`
+	PauseStart      int    `starlark:"pause_start"`
+	PauseMidway     int    `starlark:"pause_midway"`
+}
+
+// avoid having to cast to float64 to use 'math.Max'
+func MaxInt(x, y int) int {
+	if x > y {
+		return x
+	} else {
+		return y
+	}
 }
 
 func (m Marquee) FrameCount() int {
@@ -59,21 +87,15 @@ func (m Marquee) FrameCount() int {
 		size = m.Width
 	}
 
-	if cw <= size {
+	if cw <= size && !m.ScrollAlways {
 		return 1
 	}
 
-	offstart := m.OffsetStart
-	if offstart < -cw {
-		offstart = -cw
+	if m.isAlternating() {
+		return m.AlternatingFrameCount(cw, size)
+	} else {
+		return m.ScrollingFrameCount(cw, size)
 	}
-
-	offend := m.OffsetEnd
-	if offend < -cw {
-		offend = -cw
-	}
-
-	return cw + offstart + size - offend + 1
 }
 
 func (m Marquee) Paint(bounds image.Rectangle, frameIdx int) image.Image {
@@ -102,23 +124,11 @@ func (m Marquee) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		offend = -cw
 	}
 
-	loopIdx := cw + offstart
-	endIdx := cw + offstart + size - offend
-
 	var offset int
-	if cw <= size {
-		// child fits entirely and we don't want to scroll it anyway
-		offset = 0
-	} else if frameIdx <= loopIdx {
-		// first scroll child out of view
-		offset = offstart - frameIdx
-	} else if frameIdx <= endIdx {
-		// then, scroll back into view
-		offset = offend + (endIdx - frameIdx)
+	if m.isAlternating() {
+		offset = m.AlternatingOffset(cw, size, frameIdx)
 	} else {
-		// if more than FrameCount frames are requested,
-		// freeze marquee at final frame
-		offset = offend
+		offset = m.ScrollingOffset(cw, size, frameIdx)
 	}
 
 	var dc *gg.Context
@@ -131,6 +141,123 @@ func (m Marquee) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 	}
 
 	return dc.Image()
+}
+
+func (m Marquee) ScrollingFrameCount(cw int, size int) int {
+	offstart := m.OffsetStart
+	if offstart < -cw {
+		offstart = -cw
+	}
+
+	offend := m.OffsetEnd
+	if offend < -cw {
+		offend = -cw
+	}
+
+	return cw + offstart + size - offend + 1
+}
+
+func (m Marquee) ScrollingOffset(cw int, size int, frameIdx int) int {
+	offstart := m.OffsetStart
+	if offstart < -cw {
+		offstart = -cw
+	}
+
+	offend := m.OffsetEnd
+	if offend < -cw {
+		offend = -cw
+	}
+
+	loopIdx := cw + offstart
+	endIdx := cw + offstart + size - offend
+
+	if cw <= size && !m.ScrollAlways {
+		// child fits entirely and we don't want to scroll it anyway
+		return 0
+	} else if frameIdx <= loopIdx {
+		// first scroll child out of view
+		return offstart - frameIdx
+	} else if frameIdx <= endIdx {
+		// then, scroll back into view
+		return offend + (endIdx - frameIdx)
+	} else {
+		// if more than FrameCount frames are requested,
+		// freeze marquee at final frame
+		return offend
+	}
+}
+
+func (m Marquee) AlternatingFrameCount(cw int, size int) int {
+	if cw == size {
+		return 1
+	}
+
+	// calculate excess size (too much or too little space)
+	var diff int
+	if cw < size {
+		diff = size - cw
+	} else {
+		diff = cw - size
+	}
+
+	// pause values need to be at least 1
+	pauseStart := MaxInt(1, m.PauseStart)
+	pauseMidway := MaxInt(1, m.PauseMidway)
+
+	// subtract one from diff, as the start and midway points
+	// are accounted for by the pause values
+	return pauseStart + (diff - 1) + pauseMidway + (diff - 1)
+}
+
+func (m Marquee) AlternatingOffset(cw int, size int, frameIdx int) int {
+	if cw == size {
+		return 0
+	}
+
+	var diff int
+	var dir int
+	if cw < size {
+		diff = size - cw
+		dir = 1
+	} else {
+		diff = cw - size
+		dir = -1
+	}
+
+	// pause values need to be at least 1
+	pauseStart := MaxInt(1, m.PauseStart)
+	pauseMidway := MaxInt(1, m.PauseMidway)
+
+	// subtract 1 to adjust for index starting at 0
+	startIdx := pauseStart - 1
+	midwayIdx := startIdx + diff
+	continueIdx := midwayIdx + pauseMidway
+	endIdx := continueIdx + diff
+
+	if cw <= size && !m.ScrollAlways {
+		// child fits entirely and we don't want to scroll it anyway
+		return 0
+	} else if frameIdx < startIdx {
+		// paused before starting animation
+		return 0
+	} else if frameIdx < midwayIdx {
+		// scroll child into one direction
+		return dir * (frameIdx - startIdx)
+	} else if frameIdx < continueIdx {
+		// paused before changing direction
+		return dir * (midwayIdx - startIdx)
+	} else if frameIdx < endIdx {
+		// scroll child into the other direction
+		return dir * ((diff - 1) - (frameIdx - continueIdx))
+	} else {
+		// if more than FrameCount frames are requested,
+		// freeze marquee at final frame
+		return 0
+	}
+}
+
+func (m Marquee) isAlternating() bool {
+	return m.Behavior == "alternate"
 }
 
 func (m Marquee) isVertical() bool {

--- a/render/marquee_test.go
+++ b/render/marquee_test.go
@@ -292,6 +292,30 @@ func TestMarqueeOffsetEnd(t *testing.T) {
 
 }
 
+func TestMarqueeHorizontalScrollAlways(t *testing.T) {
+	child := Row{
+		Children: []Widget{
+			Box{Width: 1, Height: 1, Color: color.RGBA{0xff, 0, 0, 0xff}},
+		},
+	}
+	m := Marquee{
+		Width: 6,
+		Child: child,
+		ScrollAlways: true,
+	}
+	im := image.Rect(0, 0, 100, 100)
+
+	assert.Equal(t, 8, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"r....."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"....r."}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"...r.."}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"..r..."}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{".r...."}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"r....."}, m.Paint(im, 7)))
+}
+
 func TestMarqueeVerticalScroll(t *testing.T) {
 	child := Column{
 		Children: []Widget{
@@ -480,4 +504,191 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 8)))
 	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 9)))
 	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 1024)))
+}
+
+func TestMarqueeHorizontalAlternate(t *testing.T) {
+	child := Row{
+		Children: []Widget{
+			Box{Width: 4, Height: 1, Color: color.RGBA{0xff, 0, 0, 0xff}},
+			Box{Width: 4, Height: 1, Color: color.RGBA{0, 0xff, 0, 0xff}},
+			Box{Width: 4, Height: 1, Color: color.RGBA{0, 0, 0xff, 0xff}},
+		},
+	}
+	m := Marquee{
+		Width: 6,
+		Child: child,
+		Behavior: "alternate",
+	}
+	im := image.Rect(0, 0, 100, 100)
+
+	assert.Equal(t, 12, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"rrrrgg"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"rrrggg"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"rrgggg"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"rggggb"}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"ggggbb"}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"gggbbb"}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"gggbbb"}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"ggggbb"}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"rggggb"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"rrgggg"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"rrrggg"}, m.Paint(im, 11)))
+}
+
+func TestMarqueeVerticalAlternate(t *testing.T) {
+	child := Column{
+		Children: []Widget{
+			Box{Width: 1, Height: 4, Color: color.RGBA{0xff, 0, 0, 0xff}},
+			Box{Width: 1, Height: 4, Color: color.RGBA{0, 0xff, 0, 0xff}},
+			Box{Width: 1, Height: 4, Color: color.RGBA{0, 0, 0xff, 0xff}},
+		},
+	}
+	m := Marquee{
+		Height: 6,
+		Child: child,
+		Behavior: "alternate",
+		ScrollDirection: "vertical",
+	}
+	im := image.Rect(0, 0, 100, 100)
+
+	assert.Equal(t, 12, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","r","g","g"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","g","g","g"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","g","g","g","g"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"r","g","g","g","g","b"}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","g","b","b"}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","b","b","b"}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","b","b","b","b"}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","b","b","b"}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","g","b","b"}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"r","g","g","g","g","b"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","g","g","g","g"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","g","g","g"}, m.Paint(im, 11)))
+}
+
+func TestMarqueeHorizontalAlternateAlways(t *testing.T) {
+	child := Row{
+		Children: []Widget{
+			Box{Width: 1, Height: 1, Color: color.RGBA{0xff, 0, 0, 0xff}},
+		},
+	}
+	m := Marquee{
+		Width: 6,
+		Child: child,
+		Behavior: "alternate",
+		ScrollAlways: true,
+	}
+	im := image.Rect(0, 0, 100, 100)
+
+	assert.Equal(t, 10, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"r....."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".r...."}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"..r..."}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"...r.."}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"....r."}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"....r."}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"...r.."}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"..r..."}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".r...."}, m.Paint(im, 9)))
+}
+
+func TestMarqueeVerticalAlternateAlways(t *testing.T) {
+	child := Column{
+		Children: []Widget{
+			Box{Width: 1, Height: 1, Color: color.RGBA{0xff, 0, 0, 0xff}},
+		},
+	}
+	m := Marquee{
+		Height: 6,
+		Child: child,
+		Behavior: "alternate",
+		ScrollDirection: "vertical",
+		ScrollAlways: true,
+	}
+	im := image.Rect(0, 0, 100, 100)
+
+	assert.Equal(t, 10, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"r",".",".",".",".","."}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".","r",".",".",".","."}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".",".","r",".",".","."}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{".",".",".","r",".","."}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{".",".",".",".","r","."}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{".",".",".",".",".","r"}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{".",".",".",".","r","."}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".",".",".","r",".","."}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".",".","r",".",".","."}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".","r",".",".",".","."}, m.Paint(im, 9)))
+}
+
+func TestMarqueeHorizontalAlternatePause(t *testing.T) {
+	child := Row{
+		Children: []Widget{
+			Box{Width: 4, Height: 1, Color: color.RGBA{0xff, 0, 0, 0xff}},
+			Box{Width: 4, Height: 1, Color: color.RGBA{0, 0xff, 0, 0xff}},
+			Box{Width: 4, Height: 1, Color: color.RGBA{0, 0, 0xff, 0xff}},
+		},
+	}
+	m := Marquee{
+		Width: 6,
+		Child: child,
+		Behavior: "alternate",
+		PauseStart: 3,
+		PauseMidway: 3,
+	}
+	im := image.Rect(0, 0, 100, 100)
+	assert.Equal(t, 16, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"rrrrgg"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"rrrrgg"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"rrrrgg"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"rrrggg"}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"rrgggg"}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"rggggb"}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"ggggbb"}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"gggbbb"}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"gggbbb"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"ggggbb"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"rggggb"}, m.Paint(im, 13)))
+	assert.Equal(t, nil, checkImage([]string{"rrgggg"}, m.Paint(im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"rrrggg"}, m.Paint(im, 15)))
+}
+
+func TestMarqueeVerticalAlternatePause(t *testing.T) {
+	child := Column{
+		Children: []Widget{
+			Box{Width: 1, Height: 4, Color: color.RGBA{0xff, 0, 0, 0xff}},
+			Box{Width: 1, Height: 4, Color: color.RGBA{0, 0xff, 0, 0xff}},
+			Box{Width: 1, Height: 4, Color: color.RGBA{0, 0, 0xff, 0xff}},
+		},
+	}
+	m := Marquee{
+		Height: 6,
+		Child: child,
+		Behavior: "alternate",
+		ScrollDirection: "vertical",
+		PauseStart: 3,
+		PauseMidway: 3,
+	}
+	im := image.Rect(0, 0, 100, 100)
+	assert.Equal(t, 16, m.FrameCount())
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","r","g","g"}, m.Paint(im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","r","g","g"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","r","g","g"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","g","g","g"}, m.Paint(im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","g","g","g","g"}, m.Paint(im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"r","g","g","g","g","b"}, m.Paint(im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","g","b","b"}, m.Paint(im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","b","b","b"}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","b","b","b","b"}, m.Paint(im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","b","b","b","b"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","b","b","b","b"}, m.Paint(im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","b","b","b"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"g","g","g","g","b","b"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"r","g","g","g","g","b"}, m.Paint(im, 13)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","g","g","g","g"}, m.Paint(im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"r","r","r","g","g","g"}, m.Paint(im, 15)))
 }

--- a/runtime/generated.go
+++ b/runtime/generated.go
@@ -585,12 +585,17 @@ func newMarquee(
 ) (starlark.Value, error) {
 
 	var (
+		behavior         starlark.String
 		scroll_direction starlark.String
 
 		width        starlark.Int
 		height       starlark.Int
 		offset_start starlark.Int
 		offset_end   starlark.Int
+		pause_start  starlark.Int
+		pause_midway starlark.Int
+
+		scroll_always starlark.Bool
 
 		child starlark.Value
 	)
@@ -603,17 +608,25 @@ func newMarquee(
 		"height?", &height,
 		"offset_start?", &offset_start,
 		"offset_end?", &offset_end,
+		"behavior?", &behavior,
 		"scroll_direction?", &scroll_direction,
+		"scroll_always?", &scroll_always,
+		"pause_start?", &pause_start,
+		"pause_midway?", &pause_midway,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Marquee: %s", err)
 	}
 
 	w := &Marquee{}
+	w.Behavior = behavior.GoString()
 	w.ScrollDirection = scroll_direction.GoString()
+	w.ScrollAlways = bool(scroll_always)
 	w.Width = int(width.BigInt().Int64())
 	w.Height = int(height.BigInt().Int64())
 	w.OffsetStart = int(offset_start.BigInt().Int64())
 	w.OffsetEnd = int(offset_end.BigInt().Int64())
+	w.PauseStart = int(pause_start.BigInt().Int64())
+	w.PauseMidway = int(pause_midway.BigInt().Int64())
 
 	if child != nil {
 		childWidget, ok := child.(Widget)
@@ -636,12 +649,15 @@ func (w *Marquee) AsRenderWidget() render.Widget {
 
 func (w *Marquee) AttrNames() []string {
 	return []string{
-		"child", "width", "height", "offset_start", "offset_end", "scroll_direction",
+		"child", "width", "height", "offset_start", "offset_end", "behavior", "scroll_direction", "scroll_always", "pause_start", "pause_midway",
 	}
 }
 
 func (w *Marquee) Attr(name string) (starlark.Value, error) {
 	switch name {
+
+	case "behavior":
+		return starlark.String(w.Behavior), nil
 
 	case "scroll_direction":
 		return starlark.String(w.ScrollDirection), nil
@@ -657,6 +673,15 @@ func (w *Marquee) Attr(name string) (starlark.Value, error) {
 
 	case "offset_end":
 		return starlark.MakeInt(w.OffsetEnd), nil
+
+	case "pause_start":
+		return starlark.MakeInt(w.PauseStart), nil
+
+	case "pause_midway":
+		return starlark.MakeInt(w.PauseMidway), nil
+
+	case "scroll_always":
+		return starlark.Bool(w.ScrollAlways), nil
 
 	case "child":
 		return w.starlarkChild, nil


### PR DESCRIPTION
### Description

* Add 'behavior' option:
  - If left empty or set to 'scroll', it results in the existing marquee behavior.
  - If set to 'alternate', the child widget will be scrolled with alternating directions.
  - Attention: 'scroll' does NOT support 'pause_start' and 'pause_midway' options (see below).
  - Attention: 'alternate' does NOT support 'offset_start' and 'offset_end' options.

* Add 'scroll_always' option:
  - If left empty or set to 'False', it results in the existing marquee behavior.
  - If set to 'True', the child widget will be scrolled even if it fits entirely.

* Add 'pause_start' and 'pause_midway' options:
  - Both values default to '1', and have a minumum value of '1'.
  - They control how many frames to pause the animation at the start and at the midway
    point, before changing directions.

* Add tests for all new options.

### Examples

```starlark
behavior = "alternate",
scroll_direction = "horizontal",
```
![marquee_horizontal_alternate](https://user-images.githubusercontent.com/37808/156036001-b1e5d958-e330-45c2-8895-8120ea29506e.gif)

```starlark
behavior = "alternate",
scroll_direction = "horizontal",
pause_start = 10,
pause_midway = 10,
```
![marquee_horizontal_alternate_pause_10](https://user-images.githubusercontent.com/37808/156036215-c63cce95-d0f3-4884-9c2f-7b23d827e546.gif)

```starlark
behavior = "alternate",
scroll_direction = "horizontal",
scroll_always = True,
```
![marquee_horizontal_alternate_always](https://user-images.githubusercontent.com/37808/156036259-d6c71e78-756e-474f-bb12-b5726b87ae71.gif)

```starlark
behavior = "alternate",
scroll_direction = "vertical",
```
![marquee_vertical_alternate](https://user-images.githubusercontent.com/37808/156036297-131c4b14-fc8e-4e55-92e0-11cf832b27df.gif)

```starlark
behavior = "alternate",
scroll_direction = "vertical",
pause_start = 10,
pause_midway = 10,
```
![marquee_vertical_alternate_pause_10](https://user-images.githubusercontent.com/37808/156036322-6df3c35b-6ee3-46ce-a942-e16783495bcb.gif)

```starlark
behavior = "alternate",
scroll_direction = "vertical",
scroll_always = True,
```
![marquee_vertical_alternate_always](https://user-images.githubusercontent.com/37808/156036389-0bdca0a7-04e7-4a50-aebe-b0e7f21934c5.gif)

```starlark
behavior = "scroll",
scroll_direction = "horizontal",
scroll_always = True,
```
![marquee_horizontal_scroll_always](https://user-images.githubusercontent.com/37808/156037576-37ce4efa-1890-4b88-b99f-94cebd4ab917.gif)

