### PR TITLE
Fix OAuth 2.0 scope handling in dev tools

### DIFF
--- a/src/features/schema/fields/oauth2/OAuth2.jsx
+++ b/src/features/schema/fields/oauth2/OAuth2.jsx
@@ -13,7 +13,7 @@ export default function OAuth2({ field }) {
     const [loggedIn, setLoggedIn] = useState("");
     const dispatch = useDispatch();
     const config = useSelector(state => state.config);
-    const redirectUri =  document.location.protocol + "//" + document.location.host + "/oauth-callback"
+    const redirectUri = document.location.protocol + "//" + document.location.host + "/oauth-callback"
 
     useEffect(() => {
         if (field.id in config) {
@@ -74,7 +74,7 @@ export default function OAuth2({ field }) {
         )
     }
 
-    let scope = field.scopes.join(",");
+    let scope = field.scopes.join(" ");
     return (
         <OAuth2Login
             isCrossOrigin={true}


### PR DESCRIPTION
Multiple scopes should be space-delimeted according to RFC:
https://datatracker.ietf.org/doc/html/rfc6749#section-3.3