### PR TITLE
Maintain image aspect ratio

### DIFF
--- a/render/image.go
+++ b/render/image.go
@@ -127,10 +127,12 @@ func (p *Image) Init() error {
 	if p.Width != 0 || p.Height != 0 {
 		nw, nh := p.Width, p.Height
 		if nw == 0 {
-			nw = w
+			// scale width, maintaining original aspect ratio
+			nw = int(float64(nh)*(float64(w)/float64(h)))
 		}
 		if nh == 0 {
-			nh = h
+			// scale height, maintaining original aspect ratio
+			nh = int(float64(nw)*(float64(h)/float64(w)))
 		}
 
 		for i := 0; i < len(p.imgs); i++ {

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -75,6 +75,38 @@ func TestImageScale(t *testing.T) {
 	assert.Equal(t, 6, im.Bounds().Dy())
 }
 
+// Check that scaled image is scaled
+// maintaining aspect ratio when only width is provided
+// but don't bother checking individual pixels.
+func TestImageScaleAspectRatioWidth(t *testing.T) {
+	raw, _ := base64.StdEncoding.DecodeString(testPNG)
+	img := &Image{Src: string(raw), Width: 5}
+	img.Init()
+
+	w, h := img.Size()
+	assert.Equal(t, 5, w)
+	assert.Equal(t, 6, h)
+	im := img.Paint(image.Rect(0, 0, 0, 0), 0)
+	assert.Equal(t, 5, im.Bounds().Dx())
+	assert.Equal(t, 6, im.Bounds().Dy())
+}
+
+// Check that scaled image is scaled
+// maintaining aspect ratio when only height is provided
+// but don't bother checking individual pixels.
+func TestImageScaleAspectRatioHeight(t *testing.T) {
+	raw, _ := base64.StdEncoding.DecodeString(testPNG)
+	img := &Image{Src: string(raw), Height: 6}
+	img.Init()
+
+	w, h := img.Size()
+	assert.Equal(t, 5, w)
+	assert.Equal(t, 6, h)
+	im := img.Paint(image.Rect(0, 0, 0, 0), 0)
+	assert.Equal(t, 5, im.Bounds().Dx())
+	assert.Equal(t, 6, im.Bounds().Dy())
+}
+
 func TestImageAnimatedGif(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testGIF)
 	img := &Image{Src: string(raw)}


### PR DESCRIPTION
## tldr;
This PR updates the image logic when only a new width or new height is provided to maintain the original image aspect ratio.

## Details
Previously, if only one dimension was provided, the non-specified dimension would fall back to the original image size. For example a 640x320 image that was rendered with only a height of `32` specified would end up with a width of `640` and a height of `32`:

```
render.Image(
    src = SOME_IMAGE,
    height = 32,
)
```

With this change the new image width would be scaled to match the new height while maintaining the original image aspect ratio. So in this example the image would be rendered with a width of `64` and a height of `32`.

## Why do this?
The image size is not always known ahead of time so this makes it simpler to resize an image on the fly to properly fit in the 64x32 pixlet/tidbyt screen.

## Example

Original Image (323 × 200):
<img width="380" alt="original-image" src="https://user-images.githubusercontent.com/155808/160223569-fe284163-22bf-46fc-91e7-6d14ec9311ef.png">

Previous functionality when defining only a height of `32` would output a stretched image:
![image-test-old](https://user-images.githubusercontent.com/155808/160223579-f09ea302-263e-4cc6-8fb0-ad5eda40c09e.gif)

With this change the image maintains the original aspect ratio:
![image-test-new](https://user-images.githubusercontent.com/155808/160223572-aa8c4011-c8a1-47d6-bf9a-2c27222506a7.gif)