### PR TITLE
render/animation: Support custom easing curves.

### DIFF
--- a/render/animation/curve_test.go
+++ b/render/animation/curve_test.go
@@ -39,3 +39,23 @@ func TestEaseCurves(t *testing.T) {
 	assert.InDelta(t, 0.896000, EaseOut.Transform(0.512000), 0.01)
 	assert.InDelta(t, 1.000000, EaseOut.Transform(1.000000), 0.01)
 }
+
+func ParseAndAssertCurve(
+	t *testing.T,
+	scurve string,
+	ecurve Curve,
+) {
+	curve, err := ParseCurve(scurve)
+	assert.Nil(t, err)
+	assert.Equal(t, ecurve, curve)
+}
+
+func TestParseCurve(t *testing.T) {
+	ParseAndAssertCurve(t, "linear", LinearCurve{})
+	ParseAndAssertCurve(t, "ease_in", EaseIn)
+	ParseAndAssertCurve(t, "ease_out", EaseOut)
+	ParseAndAssertCurve(t, "ease_in_out", EaseInOut)
+	ParseAndAssertCurve(t, "cubic-bezier(0, 0, 0, 0)", CubicBezierCurve{0, 0, 0, 0})
+	ParseAndAssertCurve(t, "cubic-bezier(0.68, -0.6, 0.32, 1.6)", CubicBezierCurve{0.68, -0.6, 0.32, 1.6})
+	ParseAndAssertCurve(t, "cubic-bezier(.68, -.6, .32, 1.6)", CubicBezierCurve{0.68, -0.6, 0.32, 1.6})
+}

--- a/runtime/modules/animation_runtime/curve.go
+++ b/runtime/modules/animation_runtime/curve.go
@@ -9,9 +9,23 @@ import (
 )
 
 func CurveFromStarlark(value starlark.Value) (animation.Curve, error) {
-	if str, ok := starlark.AsString(value); ok {
-		return animation.ParseCurve(str)
+	if str, ok := value.(starlark.String); ok {
+		if str.Len() == 0 {
+			return animation.LinearCurve{}, nil
+		} else if curve, err := animation.ParseCurve(str.GoString()); err == nil {
+			return curve, nil
+		} else {
+			return animation.LinearCurve{}, fmt.Errorf("curve is not a valid curve string: %s", str.GoString())
+		}
 	}
 
-	return nil, fmt.Errorf("invalid type for curve: %s (expected string)", value.Type())
+	if fn, ok := value.(*starlark.Function); ok {
+		if fn.NumParams() != 1 || fn.NumKwonlyParams() != 0 {
+			return animation.LinearCurve{}, fmt.Errorf("invalid number of parameters to curve function: %s", fn.String())
+		}
+
+		return animation.CustomCurve{Function: fn}, nil
+	}
+
+	return animation.LinearCurve{}, nil
 }


### PR DESCRIPTION
### Description

This adds support for passing custom cubic bézier curves via the `cubic-bezier(a, b, c, d)` syntax or even passing a custom easing function implemented in Starlark.