### PR TITLE
feature: Add version command.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   lint:
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.16.12'
+          go-version: "1.16.12"
 
       - name: Install buildifier
         run: make install-buildifier
@@ -33,52 +33,60 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.16.12'
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.16.12"
 
-    - name: Install Node
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16'
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
 
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo ./scripts/setup-linux.sh
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo ./scripts/setup-linux.sh
 
-    - name: Install macOS dependencies
-      if: matrix.os == 'macos-latest'
-      run: ./scripts/setup-macos.sh
+      - name: Install macOS dependencies
+        if: matrix.os == 'macos-latest'
+        run: ./scripts/setup-macos.sh
 
-    - name: Install frontend dependencies
-      run: npm install
+      - name: Install frontend dependencies
+        run: npm install
 
-    - name: Build frontend
-      run: npm run build
+      - name: Build frontend
+        run: npm run build
 
-    - name: Build
-      run: make build
+      - name: Build
+        run: make build
 
-    - name: Test
-      run: make test
+      - name: Test
+        run: make test
 
-    - name: Build Release Linux
-      if: matrix.os == 'ubuntu-latest'
-      run: make release-linux
+      - name: Set pixlet version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
-    - name: Build Release macOS
-      if: matrix.os == 'macos-latest'
-      run: make release-macos
+      - name: Build Release Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: make release-linux
+        env:
+          PIXLET_VERSION: ${{ steps.vars.outputs.tag }}
 
-    - name: Upload Release Artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-artifacts
-        path: build
+      - name: Build Release macOS
+        if: matrix.os == 'macos-latest'
+        run: make release-macos
+        env:
+          PIXLET_VERSION: ${{ steps.vars.outputs.tag }}
+
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-artifacts
+          path: build
 
   create-release:
     name: Create Github Release
@@ -88,25 +96,25 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.16.12'
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.16.12"
 
-    - name: Fetch Release Artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: release-artifacts
+      - name: Fetch Release Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: release-artifacts
 
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        version: latest
-        args: release
-      env:
-        GITHUB_TOKEN: ${{ secrets.TIDBYT_GITHUB_TOKEN }}
-        DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
-        DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.TIDBYT_GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+GIT_COMMIT = $(shell git rev-list -1 HEAD)
+
 ifeq ($(OS),Windows_NT)
 	BINARY = pixlet.exe
-	LDFLAGS = -ldflags="-s -extldflags=-static"
+	LDFLAGS = -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=$(GIT_COMMIT)'"
 else
 	BINARY = pixlet
+	LDFLAGS = -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=$(GIT_COMMIT)'"
 endif
 
 test:
@@ -17,7 +20,7 @@ bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
 
 build: clean
-	go build $(LDFLAGS) -o $(BINARY) tidbyt.dev/pixlet
+	 go build $(LDFLAGS) -o $(BINARY) tidbyt.dev/pixlet
 
 embedfonts:
 	go run render/gen/embedfonts.go

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version string
+
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version of Pixlet",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Pixlet version: %s\n", Version)
+	},
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func init() {
 	rootCmd.AddCommand(cmd.RenderCmd)
 	rootCmd.AddCommand(cmd.PushCmd)
 	rootCmd.AddCommand(cmd.EncryptCmd)
+	rootCmd.AddCommand(cmd.VersionCmd)
 }
 
 func main() {

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,11 +21,11 @@ do
 	echo "Building ${RELEASE_PLATFORM}_${RELEASE_ARCH}"
 
 	if [[ $ARCH == "linux-arm64"  ]]; then
-		 CC=aarch64-linux-gnu-gcc CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+		 CC=aarch64-linux-gnu-gcc CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "linux-amd64"  ]]; then
-		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	else
-		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	fi
 
 	echo "Built ./build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet successfully"


### PR DESCRIPTION
# Overview
This change adds `pixlet version` to be able to determine which version of pixlet you are running 🎉 . Locally, this will default to a git commit. Our released versions will use the git tag, ex `v0.17.1`. 

# Considerations
I made sure this works locally, but I have no idea if the piping for the build system will work as expected. I also have no way to test on Windows:
```
make build && ./pixlet version
rm -f pixlet
rm -rf ./build
rm -rf ./out
go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=f61493c9c3cfbd3b4cd7809bbd08fff008e49c79'" -o pixlet tidbyt.dev/pixlet
Pixlet version: f61493c9c3cfbd3b4cd7809bbd08fff008e49c79
```

# Changes
- [feature: Add version command.](https://github.com/tidbyt/pixlet/commit/f61493c9c3cfbd3b4cd7809bbd08fff008e49c79)
    - This commit adds a version command so that folks know what version of pixlet they are currently using.