### PR TITLE
bugfix: Fix release changelog.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
 
       - name: Install Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
This commit in theory should fix the changelog for new releases. We're
currently only displaying the last commit.