### PR TITLE
Add push endpoint to pixlet serve

### DIFF
--- a/server/browser/browser.go
+++ b/server/browser/browser.go
@@ -90,6 +90,7 @@ func NewBrowser(addr string, title string, watch bool, updateChan chan loader.Up
 
 	// API endpoints to support the React frontend.
 	r.HandleFunc("/api/v1/preview", b.previewHandler)
+	r.HandleFunc("/api/v1/push", b.pushHandler)
 	r.HandleFunc("/api/v1/schema", b.schemaHandler).Methods("GET")
 	r.HandleFunc("/api/v1/handlers/{handler}", b.schemaHandlerHandler).Methods("POST")
 	r.HandleFunc("/api/v1/ws", b.websocketHandler)

--- a/server/browser/push.go
+++ b/server/browser/push.go
@@ -1,0 +1,107 @@
+package browser
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	TidbytAPIPush = "https://api.tidbyt.com/v0/devices/%s/push"
+)
+
+type TidbytPushJSON struct {
+	DeviceID       string `json:"deviceID"`
+	Image          string `json:"image"`
+	InstallationID string `json:"installationID"`
+	Background     bool   `json:"background"`
+}
+
+func (b *Browser) pushHandler(w http.ResponseWriter, r *http.Request) {
+	var (
+		deviceID       string
+		apiToken       string
+		installationID string
+		background     bool
+	)
+
+	var result map[string]interface{}
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintln(w, err)
+		return
+	}
+
+	json.Unmarshal(bodyBytes, &result)
+
+	config := make(map[string]string)
+	for k, val := range result {
+		switch k {
+		case "deviceID":
+			deviceID = val.(string)
+		case "apiToken":
+			apiToken = val.(string)
+		case "installationID":
+			installationID = val.(string)
+		case "background":
+			background = val.(string) == "true"
+		default:
+			config[k] = val.(string)
+		}
+	}
+
+	webp, err := b.loader.LoadApplet(config)
+
+	payload, err := json.Marshal(
+		TidbytPushJSON{
+			DeviceID:       deviceID,
+			Image:          webp,
+			InstallationID: installationID,
+			Background:     background,
+		},
+	)
+
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintln(w, err)
+		return
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf(TidbytAPIPush, deviceID),
+		bytes.NewReader(payload),
+	)
+
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintln(w, err)
+		return
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiToken))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		w.WriteHeader(500)
+		fmt.Fprintln(w, err)
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		fmt.Printf("Tidbyt API returned status %s\n", resp.Status)
+		w.WriteHeader(resp.StatusCode)
+		fmt.Fprintln(w, err)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		fmt.Println(string(body))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("{}"))
+}


### PR DESCRIPTION
Adds a new `/api/v1/push` endpoint to `pixlet serve` that renders the loaded applet & pushes the rendered WebP to a device using the same `apiToken `, `deviceID`, `background`, `installationID` params that [`pixlet push`](https://github.com/tidbyt/pixlet#push-to-a-tidbyt) takes. Additional JSON keys are provided to the applet being rendered as config.

I'm using this to run a local server that accepts requests from the [Home Assistant REST notification integration](https://www.home-assistant.io/integrations/notify.rest/), renders a WebP using the [vertical message applet](https://github.com/tidbyt/community/blob/main/apps/verticalmessage/vertical_message.star) and the provided `msg`, and pushes it to my Tidbyt like so:

```
notify:
  - name: tidbyt
    platform: rest
    resource: http://pixlet:8080/api/v1/push
    method: POST_JSON
    message_param_name: msg
    data:
      installationID: home-assistant-tidbyt
      deviceID: !env_var TIDBYT_DEVICE_ID
      apiToken: !env_var TIDBYT_API_TOKEN
      background: "false"
      
```

This allows me to send my Tidbyt timely notifications in response to events that happen around it (like a doorbell ringing).