### PR TITLE
bugfix: Pin goreleaser version.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.7.0
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.TIDBYT_GITHUB_TOKEN }}


### PR DESCRIPTION
This commit pins the version of goreleaser we are using. Fixes #268 