### PR TITLE
Fix WrappedText Linespacing

### DIFF
--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -67,7 +67,7 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		if lw > w {
 			w = lw
 		}
-		h += lh
+		h += lh+float64(tw.LineSpacing)
 	}
 
 	// Size of drawing context

--- a/render/wrappedtext_test.go
+++ b/render/wrappedtext_test.go
@@ -115,7 +115,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 
 	// Single pixel line space
 	text := WrappedText{Content: "AB CD.", LineSpacing: 1}
-	im := text.Paint(image.Rect(0, 0, 21, 17), 0)
+	im := text.Paint(image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
 		".ww.." + "www....",
@@ -137,7 +137,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 
 	// Add another one
 	text = WrappedText{Content: "AB CD.", LineSpacing: 2}
-	im = text.Paint(image.Rect(0, 0, 21, 17), 0)
+	im = text.Paint(image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
 		".ww.." + "www....",
@@ -154,6 +154,6 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 		"w..w." + "w..w...",
 		"w...." + "w..w...",
 		"w...." + "w..w...",
-		"w..w." + "w..w...", // truncation here
+		"w..w." + "w..w...",
 	}, im))
 }


### PR DESCRIPTION
So am not sure if this is the only thing that is needed to fix #135. But it works for my use case for the fix the vertical scroll in the open [PR here](https://github.com/tidbyt/community/pull/369).

Readjusted to fix vertical issue by submitting a PR fix to wrapped text in pixlet.

Without this merge, the last line will just be cut off, so won't be much different for vertical scroll prior to that PR. 

