### PR TITLE
`render.WrappedText': Add Option for text alignment

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,1 +1,1 @@
-<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="initial-scale=1,width=device-width"/><title>Pixlet</title><link rel="icon" href="/static/favicon.png"><script defer="defer" src="/static/main.e42f2ff4fe5d5c5a8f1e.js"></script></head><body><div id="app"></div></body></html>
+<! -- Generated! Do not commit changes! -->

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,1 +1,1 @@
-<! -- Generated! Do not commit changes! -->
+<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="initial-scale=1,width=device-width"/><title>Pixlet</title><link rel="icon" href="/static/favicon.png"><script defer="defer" src="/static/main.e42f2ff4fe5d5c5a8f1e.js"></script></head><body><div id="app"></div></body></html>

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -413,8 +413,7 @@ The optional `width` and `height` parameters limit the drawing
 area. If not set, WrappedText will use as much vertical and
 horizontal space as possible to fit the text.
 
-Alignment of the text is controlled by passing one of the following `alignment` values:
-one of the following `cross_align` values:
+Alignment of the text is controlled by passing one of the following `align` values:
 - `"left"`: align text to the left
 - `"center"`: align text in the center
 - `"right"`: align text to the right
@@ -427,7 +426,7 @@ one of the following `cross_align` values:
 | `width` | `int` | Limits width of the area on which text may be drawn | N |
 | `linespacing` | `int` | Controls spacing between lines | N |
 | `color` | `color` | Desired font color | N |
-| `alignment` | `str` | Text Alignment | N |
+| `align` | `str` | Text Alignment | N |
 
 #### Example
 ```

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -413,6 +413,11 @@ The optional `width` and `height` parameters limit the drawing
 area. If not set, WrappedText will use as much vertical and
 horizontal space as possible to fit the text.
 
+Alignment of the text is controlled by passing one of the following `alignment` values:
+one of the following `cross_align` values:
+- `"left"`: align text to the left
+- `"center"`: align text in the center
+- `"right"`: align text to the right
 #### Attributes
 | Name | Type | Description | Required |
 | --- | --- | --- | --- |
@@ -422,6 +427,7 @@ horizontal space as possible to fit the text.
 | `width` | `int` | Limits width of the area on which text may be drawn | N |
 | `linespacing` | `int` | Controls spacing between lines | N |
 | `color` | `color` | Desired font color | N |
+| `alignment` | `str` | Text Alignment | N |
 
 #### Example
 ```

--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -19,7 +19,7 @@ import (
 // DOC(Width): Limits width of the area on which text may be drawn
 // DOC(LineSpacing): Controls spacing between lines
 // DOC(Color): Desired font color
-// DOC(Alignment): Text Alignment
+// DOC(Align): Text Alignment
 // EXAMPLE BEGIN
 // render.WrappedText(
 //       content="this is a multi-line text string",
@@ -36,7 +36,7 @@ type WrappedText struct {
 	Width       int
 	LineSpacing int
 	Color       color.Color
-	Alignment   string
+	Align   	string
 }
 
 func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
@@ -45,13 +45,13 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		face = Font[tw.Font]
 	}
 	// Text alignment
-	alignment := gg.AlignLeft
-	if tw.Alignment == "center" {
-		alignment = gg.AlignCenter
-	} else if tw.Alignment == "right" {
-		alignment = gg.AlignRight
+	align := gg.AlignLeft
+	if tw.Align == "center" {
+		align = gg.AlignCenter
+	} else if tw.Align == "right" {
+		align = gg.AlignRight
 	} else {
-		alignment = gg.AlignLeft
+		align = gg.AlignLeft
 	}
 	// The bounds provided by user or parent widget
 	width := tw.Width
@@ -116,7 +116,7 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		0,
 		float64(width),
 		(float64(tw.LineSpacing)+dc.FontHeight())/dc.FontHeight(),
-		alignment,
+		align,
 	)
 
 	return dc.Image()

--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -50,8 +50,6 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		align = gg.AlignCenter
 	} else if tw.Align == "right" {
 		align = gg.AlignRight
-	} else {
-		align = gg.AlignLeft
 	}
 	// The bounds provided by user or parent widget
 	width := tw.Width

--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -60,7 +60,10 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 	if height == 0 {
 		height = bounds.Dy()
 	}
-
+	linespace := float64(tw.LineSpacing)
+	if linespace <=0{ 
+		linespace = 0
+	}
 	// Compute size of multi line string
 	//
 	// NOTE: Can't use dc.MeasureMultilineString() here. It only
@@ -74,7 +77,7 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		if lw > w {
 			w = lw
 		}
-		h += lh+float64(tw.LineSpacing)
+		h += lh+linespace
 	}
 
 	// Size of drawing context

--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -19,7 +19,7 @@ import (
 // DOC(Width): Limits width of the area on which text may be drawn
 // DOC(LineSpacing): Controls spacing between lines
 // DOC(Color): Desired font color
-//
+// DOC(Alignment): Text Alignment
 // EXAMPLE BEGIN
 // render.WrappedText(
 //       content="this is a multi-line text string",
@@ -36,6 +36,7 @@ type WrappedText struct {
 	Width       int
 	LineSpacing int
 	Color       color.Color
+	Alignment   string
 }
 
 func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
@@ -43,7 +44,15 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 	if tw.Font != "" {
 		face = Font[tw.Font]
 	}
-
+	// Text alignment
+	alignment := gg.AlignLeft
+	if tw.Alignment == "center" {
+		alignment = gg.AlignCenter
+	} else if tw.Alignment == "right" {
+		alignment = gg.AlignRight
+	} else {
+		alignment = gg.AlignLeft
+	}
 	// The bounds provided by user or parent widget
 	width := tw.Width
 	if width == 0 {
@@ -107,7 +116,7 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		0,
 		float64(width),
 		(float64(tw.LineSpacing)+dc.FontHeight())/dc.FontHeight(),
-		gg.AlignLeft,
+		alignment,
 	)
 
 	return dc.Image()

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -1457,7 +1457,7 @@ func newWrappedText(
 		width       starlark.Int
 		linespacing starlark.Int
 		color       starlark.String
-		alignment   starlark.String
+		align   starlark.String
 	)
 
 	if err := starlark.UnpackArgs(
@@ -1469,7 +1469,7 @@ func newWrappedText(
 		"width?", &width,
 		"linespacing?", &linespacing,
 		"color?", &color,
-		"alignment?", &alignment,
+		"align?", &align,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for WrappedText: %s", err)
 	}
@@ -1494,7 +1494,7 @@ func newWrappedText(
 		}
 		w.Color = c
 	}
-	w.Alignment = alignment.GoString()
+	w.Align = align.GoString()
 
 	return w, nil
 }
@@ -1505,7 +1505,7 @@ func (w *WrappedText) AsRenderWidget() render.Widget {
 
 func (w *WrappedText) AttrNames() []string {
 	return []string{
-		"content", "font", "height", "width", "linespacing", "color", "alignment",
+		"content", "font", "height", "width", "linespacing", "color", "align",
 	}
 }
 

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -1457,6 +1457,7 @@ func newWrappedText(
 		width       starlark.Int
 		linespacing starlark.Int
 		color       starlark.String
+		alignment   starlark.String
 	)
 
 	if err := starlark.UnpackArgs(
@@ -1468,6 +1469,7 @@ func newWrappedText(
 		"width?", &width,
 		"linespacing?", &linespacing,
 		"color?", &color,
+		"alignment?", &alignment,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for WrappedText: %s", err)
 	}
@@ -1492,6 +1494,7 @@ func newWrappedText(
 		}
 		w.Color = c
 	}
+	w.Alignment = alignment.GoString()
 
 	return w, nil
 }
@@ -1502,7 +1505,7 @@ func (w *WrappedText) AsRenderWidget() render.Widget {
 
 func (w *WrappedText) AttrNames() []string {
 	return []string{
-		"content", "font", "height", "width", "linespacing", "color",
+		"content", "font", "height", "width", "linespacing", "color", "alignment",
 	}
 }
 


### PR DESCRIPTION
This PR adds the option for text alignment with `render.WrappedText`.

I think there should be an additional test in the `wrappedtext_test.go` file. But is there an easy way to make the image output of what to expect instead of manually doing it? 

As there currently is no change to the testing file. Also not sure if I did the go syntax as it should be. 