### PR TITLE
render: better handling of optimized GIFs

### DIFF
--- a/encode/encode.go
+++ b/encode/encode.go
@@ -151,7 +151,7 @@ func (s *Screens) EncodeGIF(filters ...ImageFilter) ([]byte, error) {
 
 		palette := quantize.MedianCutQuantizer{}.Quantize(make([]color.Color, 0, 256), im)
 		imPaletted := image.NewPaletted(imRGBA.Bounds(), palette)
-		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{0, 0}, draw.Src)
+		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.ZP, draw.Src)
 
 		g.Image = append(g.Image, imPaletted)
 		g.Delay = append(g.Delay, int(s.delay/10)) // in 100ths of a second

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -151,7 +151,7 @@ func (s *Screens) EncodeGIF(filters ...ImageFilter) ([]byte, error) {
 
 		palette := quantize.MedianCutQuantizer{}.Quantize(make([]color.Color, 0, 256), im)
 		imPaletted := image.NewPaletted(imRGBA.Bounds(), palette)
-		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.ZP, draw.Src)
+		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{}, draw.Src)
 
 		g.Image = append(g.Image, imPaletted)
 		g.Delay = append(g.Delay, int(s.delay/10)) // in 100ths of a second

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -151,7 +151,7 @@ func (s *Screens) EncodeGIF(filters ...ImageFilter) ([]byte, error) {
 
 		palette := quantize.MedianCutQuantizer{}.Quantize(make([]color.Color, 0, 256), im)
 		imPaletted := image.NewPaletted(imRGBA.Bounds(), palette)
-		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{}, draw.Src)
+		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{0, 0}, draw.Src)
 
 		g.Image = append(g.Image, imPaletted)
 		g.Delay = append(g.Delay, int(s.delay/10)) // in 100ths of a second

--- a/render/image.go
+++ b/render/image.go
@@ -71,15 +71,8 @@ func (p *Image) InitFromWebP(data []byte) error {
 }
 
 func (p *Image) InitFromGIF(data []byte) error {
-	// GIF support is quite limited and can't handle different
-	// positioned and sized frames, as well as disposal types.
-	//
-	// This means that many more optimized GIFs will not render
-	// correctly, with frame contents jumping around and previous
-	// frame contents always getting disposed, instead of kept.
-	//
-	// Unfortunatley the 'image/gif' package does not even expose
-	// frame positions, making it hard to implement these features.
+	// GIF support is a bit limited. Some optimized GIFs will not
+	// render correctly.
 	//
 	// Consider using WebP instead.
 	img, err := gif.DecodeAll(bytes.NewReader(data))
@@ -88,10 +81,20 @@ func (p *Image) InitFromGIF(data []byte) error {
 	}
 
 	p.Delay = img.Delay[0] * 10
-	for _, im := range img.Image {
-		imRGBA := image.NewRGBA(image.Rect(0, 0, im.Bounds().Dx(), im.Bounds().Dy()))
-		draw.Draw(imRGBA, imRGBA.Bounds(), im, image.Point{0, 0}, draw.Src)
-		p.imgs = append(p.imgs, imRGBA)
+
+	last := image.NewRGBA(image.Rect(0, 0, img.Image[0].Bounds().Dx(), img.Image[0].Bounds().Dy()))
+	draw.Draw(last, last.Bounds(), img.Image[0], image.ZP, draw.Src)
+
+	for _, src := range img.Image {
+
+		// Note: We're not really handling all disposal
+		// methods here, but this seems to be good enough.
+		draw.Draw(last, last.Bounds(), src, image.Point{0, 0}, draw.Over)
+		frame := *last
+		frame.Pix = make([]uint8, len(last.Pix))
+		copy(frame.Pix, last.Pix)
+
+		p.imgs = append(p.imgs, &frame)
 	}
 
 	return nil
@@ -128,11 +131,11 @@ func (p *Image) Init() error {
 		nw, nh := p.Width, p.Height
 		if nw == 0 {
 			// scale width, maintaining original aspect ratio
-			nw = int(float64(nh)*(float64(w)/float64(h)))
+			nw = int(float64(nh) * (float64(w) / float64(h)))
 		}
 		if nh == 0 {
 			// scale height, maintaining original aspect ratio
-			nh = int(float64(nw)*(float64(h)/float64(w)))
+			nh = int(float64(nw) * (float64(h) / float64(w)))
 		}
 
 		for i := 0; i < len(p.imgs); i++ {

--- a/render/image.go
+++ b/render/image.go
@@ -89,7 +89,7 @@ func (p *Image) InitFromGIF(data []byte) error {
 
 		// Note: We're not really handling all disposal
 		// methods here, but this seems to be good enough.
-		draw.Draw(last, last.Bounds(), src, image.Point{0, 0}, draw.Over)
+		draw.Draw(last, last.Bounds(), src, image.ZP, draw.Over)
 		frame := *last
 		frame.Pix = make([]uint8, len(last.Pix))
 		copy(frame.Pix, last.Pix)

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -12,9 +12,6 @@ import (
 // plus sign on a transparent background.
 const testPNG = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAMCAYAAABbayygAAAAOUlEQVQoU2P8z8Dwn4EIwAhSyMjAwIhPLVgNukKYDciaaawQl6dATkCxmmiFMF8PgGeICnAiYpABACrQO/WD80OVAAAAAElFTkSuQmCC"
 
-// Animated GIF with a few pixels moving around
-const testGIF = "R0lGODlhBQAEAPAAAAAAAAAAACH5BAF7AAAAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAABQAEAAACBgRiaLmLBQAh+QQBewAAACwAAAAABQAEAAACBYRzpqhXACH5BAF7AAAALAAAAAAFAAQAAAIGDG6Qp8wFACH5BAF7AAAALAAAAAAFAAQAAAIGRIBnyMoFADs="
-
 func TestImage(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
 	img := &Image{Src: string(raw)}
@@ -108,6 +105,20 @@ func TestImageScaleAspectRatioHeight(t *testing.T) {
 }
 
 func TestImageAnimatedGif(t *testing.T) {
+	// Animated 5x4 GIF with 4 frames:
+	//
+	// frame 0: ..x..
+	//          x....
+	//          .x...
+	//          ...x.
+	//
+	// Subsequent frames shift pixels right, overflowing into the
+	// next row.
+	//
+	// GIF has no disposal method set, and a delay of 1230 ms
+
+	const testGIF = "R0lGODlhBQAEAPAAAAAAAAAAACH5BAF7AAAAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAABQAEAAACBgRiaLmLBQAh+QQBewAAACwAAAAABQAEAAACBYRzpqhXACH5BAF7AAAALAAAAAAFAAQAAAIGDG6Qp8wFACH5BAF7AAAALAAAAAAFAAQAAAIGRIBnyMoFADs="
+
 	raw, _ := base64.StdEncoding.DecodeString(testGIF)
 	img := &Image{Src: string(raw)}
 	img.Init()
@@ -127,23 +138,26 @@ func TestImageAnimatedGif(t *testing.T) {
 		".x...",
 		"...x.",
 	}, img.Paint(image.Rect(0, 0, 100, 100), 0)))
+
+	// since no disposal method is set, subsequent frames should
+	// draw on top of first frame
 	assert.Equal(t, nil, checkImage([]string{
-		"...x.",
-		".x...",
-		"..x..",
-		"....x",
+		"..xx.",
+		"xx...",
+		".xx..",
+		"...xx",
 	}, img.Paint(image.Rect(0, 0, 100, 100), 1)))
 	assert.Equal(t, nil, checkImage([]string{
-		"x...x",
-		"..x..",
-		"...x.",
-		".....",
+		"x.xxx",
+		"xxx..",
+		".xxx.",
+		"...xx",
 	}, img.Paint(image.Rect(0, 0, 100, 100), 2)))
 	assert.Equal(t, nil, checkImage([]string{
-		".x...",
-		"x..x.",
-		"....x",
-		".....",
+		"xxxxx",
+		"xxxx.",
+		".xxxx",
+		"...xx",
 	}, img.Paint(image.Rect(0, 0, 100, 100), 3)))
 
 	// loops after the last frame
@@ -154,9 +168,9 @@ func TestImageAnimatedGif(t *testing.T) {
 		"...x.",
 	}, img.Paint(image.Rect(0, 0, 100, 100), 4)))
 	assert.Equal(t, nil, checkImage([]string{
-		"...x.",
-		".x...",
-		"..x..",
-		"....x",
+		"..xx.",
+		"xx...",
+		".xx..",
+		"...xx",
 	}, img.Paint(image.Rect(0, 0, 100, 100), 5)))
 }


### PR DESCRIPTION
Doesn't support all disposal methods, but seems to cover a broad range of "optimized" GIFs.