### PR TITLE
Marquee: Add fix for alignment of non-scrolling child

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -192,6 +192,12 @@ If the child's width fits fully, it will not scroll.
 The `offset_start` and `offset_end` parameters control the position
 of the child in the beginning and the end of the animation.
 
+Alignment for a child that fits fully along the horizontal/vertical axis is controlled by passing
+one of the following `align` values:
+- `"start"`: place child at the left/top
+- `"end"`: place child at the right/bottom
+- `"center"`: place child at the center
+
 #### Attributes
 | Name | Type | Description | Required |
 | --- | --- | --- | --- |
@@ -201,7 +207,7 @@ of the child in the beginning and the end of the animation.
 | `offset_start` | `int` | Position of child at beginning of animation | N |
 | `offset_end` | `int` | Position of child at end of animation | N |
 | `scroll_direction` | `str` | Direction to scroll, 'vertical' or 'horizontal', default is horizontal | N |
-
+| `align` | `str` | Alignment of child that fits fully, default is 'start' | N |
 #### Example
 ```
 render.Marquee(

--- a/render/marquee.go
+++ b/render/marquee.go
@@ -27,6 +27,7 @@ import (
 // DOC(OffsetStart): Position of child at beginning of animation
 // DOC(OffsetEnd): Position of child at end of animation
 // DOC(ScrollDirection): Direction to scroll, 'vertical' or 'horizontal', default is horizontal
+// DOC(Align): alignment when contents fit on screen, 'start', 'center' or 'end', default is start
 //
 // EXAMPLE BEGIN
 // render.Marquee(
@@ -44,6 +45,7 @@ type Marquee struct {
 	OffsetStart     int    `starlark:"offset_start"`
 	OffsetEnd       int    `starlark:"offset_end"`
 	ScrollDirection string `starlark:"scroll_direction"`
+	Align			string `starlark:"align"`
 }
 
 func (m Marquee) FrameCount() int {
@@ -112,10 +114,20 @@ func (m Marquee) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 	loopIdx := cw + offstart
 	endIdx := cw + offstart + size - offend
 
+	align := 0.0 //default is align="start"
 	var offset int
 	if cw <= size {
 		// child fits entirely and we don't want to scroll it anyway
 		offset = 0
+
+		//modify alignment 
+		if m.Align=="center" {
+			align = 0.5
+			offset = size/2
+		} else if m.Align=="end" {
+			align = 1.0
+			offset = size
+		}
 	} else if frameIdx <= loopIdx {
 		// first scroll child out of view
 		offset = offstart - frameIdx
@@ -131,10 +143,10 @@ func (m Marquee) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 	var dc *gg.Context
 	if m.isVertical() {
 		dc = gg.NewContext(im.Bounds().Dx(), m.Height)
-		dc.DrawImage(im, 0, offset)
+		dc.DrawImageAnchored(im,0,offset,0,align)
 	} else {
 		dc = gg.NewContext(m.Width, im.Bounds().Dy())
-		dc.DrawImage(im, offset, 0)
+		dc.DrawImageAnchored(im,offset,0,align,0)
 	}
 
 	return dc.Image()

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -620,6 +620,7 @@ func newMarquee(
 		offset_start     starlark.Int
 		offset_end       starlark.Int
 		scroll_direction starlark.String
+		align			 starlark.String
 	)
 
 	if err := starlark.UnpackArgs(
@@ -631,6 +632,7 @@ func newMarquee(
 		"offset_start?", &offset_start,
 		"offset_end?", &offset_end,
 		"scroll_direction?", &scroll_direction,
+		"align?", & align,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Marquee: %s", err)
 	}
@@ -659,6 +661,8 @@ func newMarquee(
 
 	w.ScrollDirection = scroll_direction.GoString()
 
+	w.Align = align.GoString()
+
 	return w, nil
 }
 
@@ -668,7 +672,7 @@ func (w *Marquee) AsRenderWidget() render.Widget {
 
 func (w *Marquee) AttrNames() []string {
 	return []string{
-		"child", "width", "height", "offset_start", "offset_end", "scroll_direction",
+		"child", "width", "height", "offset_start", "offset_end", "scroll_direction", "align",
 	}
 }
 
@@ -698,7 +702,8 @@ func (w *Marquee) Attr(name string) (starlark.Value, error) {
 	case "scroll_direction":
 
 		return starlark.String(w.ScrollDirection), nil
-
+	case "align":
+		return starlark.String(w.Align), nil
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
This allows for alignment of the child when it fits fully, this is especially useful for when text changes and may or may not fit.

It should work with other child objects, but unit tests should be used to confirm the intended behavior.

This should resolve #295 and I thing would really only be an issue there, so if this needs to be fixed elsewhere let me know. 

