### PR TITLE
feature: Add fill colors to render.Plot()

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -246,6 +246,8 @@ Plot is a widget that draws a data series.
 | `x_lim` | `(float, float)` | Limit X-axis to a range | N |
 | `y_lim` | `(float, float)` | Limit Y-axis to a range | N |
 | `fill` | `bool` | Paint surface between line and X-axis | N |
+| `fill_color` | `color` |  | N |
+| `fill_color_inverted` | `color` |  | N |
 
 #### Example
 ```

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -246,8 +246,8 @@ Plot is a widget that draws a data series.
 | `x_lim` | `(float, float)` | Limit X-axis to a range | N |
 | `y_lim` | `(float, float)` | Limit Y-axis to a range | N |
 | `fill` | `bool` | Paint surface between line and X-axis | N |
-| `fill_color` | `color` |  | N |
-| `fill_color_inverted` | `color` |  | N |
+| `fill_color` | `color` | Fill color for Y-values above 0 | N |
+| `fill_color_inverted` | `color` | Fill color for Y-values below 0 | N |
 
 #### Example
 ```

--- a/render/plot.go
+++ b/render/plot.go
@@ -19,11 +19,12 @@ var FillAlpha uint8 = 0x55
 // DOC(Width): Limits Plot width
 // DOC(Height): Limits Plot height
 // DOC(Color): Line color, default is '#fff'
-// DOC(ColorFill): Line color for Y-values above 0
 // DOC(ColorInverted): Line color for Y-values below 0
 // DOC(XLim): Limit X-axis to a range
 // DOC(YLim): Limit Y-axis to a range
 // DOC(Fill): Paint surface between line and X-axis
+// DOC(FillColor): Fill color for Y-values above 0
+// DOC(FillColorInverted): Fill color for Y-values below 0
 //
 // EXAMPLE BEGIN
 // render.Plot(

--- a/render/plot.go
+++ b/render/plot.go
@@ -19,6 +19,7 @@ var FillAlpha uint8 = 0x55
 // DOC(Width): Limits Plot width
 // DOC(Height): Limits Plot height
 // DOC(Color): Line color, default is '#fff'
+// DOC(ColorFill): Line color for Y-values above 0
 // DOC(ColorInverted): Line color for Y-values below 0
 // DOC(XLim): Limit X-axis to a range
 // DOC(YLim): Limit Y-axis to a range
@@ -69,6 +70,12 @@ type Plot struct {
 
 	// If true, also paint surface between line and X-axis
 	Fill bool `starlark:"fill"`
+
+	// Optional fill color for Y-values above 0
+	FillColor color.Color `starlark:"fill_color"`
+
+	// Optional fill color for Y-values below 0
+	FillColorInverted color.Color `starlark:"fill_color_inverted"`
 
 	invThreshold int
 }
@@ -193,8 +200,16 @@ func (p Plot) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 	if p.ColorInverted != nil {
 		colInv = p.ColorInverted
 	}
+
 	fillCol := colorWithAlpha(col, FillAlpha)
+	if p.FillColor != nil {
+		fillCol = p.FillColor
+	}
+
 	fillColInv := colorWithAlpha(colInv, FillAlpha)
+	if p.FillColorInverted != nil {
+		fillColInv = p.FillColorInverted
+	}
 
 	pl := &PolyLine{Vertices: p.translatePoints()}
 

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -869,6 +869,10 @@ type Plot struct {
 	starlarkXLim starlark.Tuple
 
 	starlarkYLim starlark.Tuple
+
+	starlarkFillColor starlark.String
+
+	starlarkFillColorInverted starlark.String
 }
 
 func newPlot(
@@ -879,14 +883,16 @@ func newPlot(
 ) (starlark.Value, error) {
 
 	var (
-		data           *starlark.List
-		width          starlark.Int
-		height         starlark.Int
-		color          starlark.String
-		color_inverted starlark.String
-		x_lim          starlark.Tuple
-		y_lim          starlark.Tuple
-		fill           starlark.Bool
+		data                *starlark.List
+		width               starlark.Int
+		height              starlark.Int
+		color               starlark.String
+		color_inverted      starlark.String
+		x_lim               starlark.Tuple
+		y_lim               starlark.Tuple
+		fill                starlark.Bool
+		fill_color          starlark.String
+		fill_color_inverted starlark.String
 	)
 
 	if err := starlark.UnpackArgs(
@@ -900,6 +906,8 @@ func newPlot(
 		"x_lim?", &x_lim,
 		"y_lim?", &y_lim,
 		"fill?", &fill,
+		"fill_color?", &fill_color,
+		"fill_color_inverted?", &fill_color_inverted,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Plot: %s", err)
 	}
@@ -951,6 +959,24 @@ func newPlot(
 
 	w.Fill = bool(fill)
 
+	w.starlarkFillColor = fill_color
+	if fill_color.Len() > 0 {
+		c, err := render.ParseColor(fill_color.GoString())
+		if err != nil {
+			return nil, fmt.Errorf("fill_color is not a valid hex string: %s", fill_color.String())
+		}
+		w.FillColor = c
+	}
+
+	w.starlarkFillColorInverted = fill_color_inverted
+	if fill_color_inverted.Len() > 0 {
+		c, err := render.ParseColor(fill_color_inverted.GoString())
+		if err != nil {
+			return nil, fmt.Errorf("fill_color_inverted is not a valid hex string: %s", fill_color_inverted.String())
+		}
+		w.FillColorInverted = c
+	}
+
 	return w, nil
 }
 
@@ -960,7 +986,7 @@ func (w *Plot) AsRenderWidget() render.Widget {
 
 func (w *Plot) AttrNames() []string {
 	return []string{
-		"data", "width", "height", "color", "color_inverted", "x_lim", "y_lim", "fill",
+		"data", "width", "height", "color", "color_inverted", "x_lim", "y_lim", "fill", "fill_color", "fill_color_inverted",
 	}
 }
 
@@ -998,6 +1024,14 @@ func (w *Plot) Attr(name string) (starlark.Value, error) {
 	case "fill":
 
 		return starlark.Bool(w.Fill), nil
+
+	case "fill_color":
+
+		return w.starlarkFillColor, nil
+
+	case "fill_color_inverted":
+
+		return w.starlarkFillColorInverted, nil
 
 	default:
 		return nil, nil
@@ -1544,7 +1578,7 @@ func newWrappedText(
 		width       starlark.Int
 		linespacing starlark.Int
 		color       starlark.String
-		align   starlark.String
+		align       starlark.String
 	)
 
 	if err := starlark.UnpackArgs(
@@ -1581,6 +1615,7 @@ func newWrappedText(
 		}
 		w.Color = c
 	}
+
 	w.Align = align.GoString()
 
 	return w, nil
@@ -1622,6 +1657,10 @@ func (w *WrappedText) Attr(name string) (starlark.Value, error) {
 	case "color":
 
 		return w.starlarkColor, nil
+
+	case "align":
+
+		return starlark.String(w.Align), nil
 
 	default:
 		return nil, nil


### PR DESCRIPTION
# Overview
We support a line color, but not a fill color. This commit adds support for a fill color and an inverted fill color to override the alpha calculation.

# Changes
- [feature: Add fill colors to render.Plot()](https://github.com/tidbyt/pixlet/commit/b401efb1a04ed7673fce1a60b238b161fa0ab09a) 
    - This commit adds the ability to add a fill color to a plot to override the alpha calculation.