### PR TITLE
fix: Remove quotes from qrcode.

### DIFF
--- a/runtime/modules/qrcode/qrcode.go
+++ b/runtime/modules/qrcode/qrcode.go
@@ -71,7 +71,7 @@ func generateQRCode(thread *starlark.Thread, _ *starlark.Builtin, args starlark.
 		return nil, fmt.Errorf("size must be small, medium, or large")
 	}
 
-	url := starUrl.String()
+	url := starUrl.GoString()
 	code, err := goqrcode.NewWithForcedVersion(url, version, goqrcode.Low)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit fixes a bug where the URL contains quotes.