### PR TITLE
feature: Add Generated support.

### DIFF
--- a/docs/schema/generated/example.star
+++ b/docs/schema/generated/example.star
@@ -1,0 +1,77 @@
+load("render.star", "render")
+load("schema.star", "schema")
+
+def main(config):
+    pet = config.get("pet", "turtle")
+    children = [
+        render.Marquee(
+            width = 64,
+            child = render.Text("pet: %s" % pet),
+        ),
+    ]
+
+    if pet == "dog":
+        has_leash = config.bool("leash", False)
+        children.append(
+            render.Marquee(
+                width = 64,
+                child = render.Text("has leash: %s" % has_leash),
+            ),
+        )
+
+    if pet == "cat":
+        has_litter_box = config.bool("litter-box", False)
+        children.append(
+            render.Marquee(
+                width = 64,
+                child = render.Text("has litter box: %s" % has_litter_box),
+            ),
+        )
+
+    return render.Root(
+        child = render.Column(
+            children = children,
+        ),
+    )
+
+def more_options(pet):
+    if pet == "dog":
+        return [
+            schema.Toggle(
+                id = "leash",
+                name = "Leash",
+                desc = "A toggle to enable a dog leash.",
+                icon = "cog",
+                default = False,
+            ),
+        ]
+    elif pet == "cat":
+        return [
+            schema.Toggle(
+                id = "litter-box",
+                name = "Litter Box",
+                desc = "A toggle to enable a litter box.",
+                icon = "cog",
+                default = False,
+            ),
+        ]
+    else:
+        return []
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "pet",
+                name = "Pet Type",
+                desc = "What type of pet do you have?",
+                icon = "cog",
+            ),
+            schema.Generated(
+                id = "generated",
+                source = "pet",
+                handler = more_options,
+            ),
+        ],
+    )

--- a/docs/schema/schema.md
+++ b/docs/schema/schema.md
@@ -118,6 +118,55 @@ schema.Dropdown(
 )
 ```
 
+### Generated
+> [Example App](generated/example.star)
+
+The generated field allows for a schema field to generate additional schema
+fields 🤯. User beware - this field is both not user friendly and our tooling
+likely has a fair number of bugs. The benefit though is the ability to ask the
+user for additional fields depending on their input. 
+
+
+In this example, `source` is the `id` of the field that will be passed to the
+`handler`. So if there is a text field with `id = pet`, the value of the pet
+text field will be passed to `more_options`:
+```starlark
+schema.Generated(
+    id = "generated",
+    source = "pet",
+    handler = more_options,
+)
+```
+
+Note - the value that is passed to the handler is dependent on the source field
+type. A handler might look as follows:
+
+```starlark
+def more_options(pet):
+    if pet == "dog":
+        return [
+            schema.Toggle(
+                id = "leash",
+                name = "Leash",
+                desc = "A toggle to enable a dog leash.",
+                icon = "cog",
+                default = False,
+            ),
+        ]
+    elif pet == "cat":
+        return [
+            schema.Toggle(
+                id = "litter-box",
+                name = "Litter Box",
+                desc = "A toggle to enable a litter box.",
+                icon = "cog",
+                default = False,
+            ),
+        ]
+    else:
+        return []
+```
+
 ### Location
 ![location example](location/location.gif)
 > [Example App](location/example.star)

--- a/src/features/handlers/actions.js
+++ b/src/features/handlers/actions.js
@@ -1,6 +1,7 @@
 
 import axios from 'axios';
 import { update, loading } from './handlerSlice';
+import { updateGenerated } from '../schema/schemaSlice';
 import { set as setError } from '../errors/errorSlice';
 import store from "../../store";
 
@@ -22,6 +23,28 @@ export function callHandler(id, handler, param) {
     axios.post('/api/v1/handlers/' + handler, JSON.stringify(data))
         .then(res => {
             store.dispatch(update({ id: id, value: res.data }));
+        })
+        .catch(err => {
+            // TODO: make sure this clears.
+            const msg = parseErrorMessage(handler, err);
+            store.dispatch(setError({ id: msg, message: msg }));
+            console.log(err);
+        })
+        .then(() => {
+            store.dispatch(loading(false));
+        })
+}
+
+export function callGeneratedHandler(id, handler, param) {
+    let data = {
+        id: id,
+        param: param
+    }
+
+    store.dispatch(loading(true));
+    axios.post('/api/v1/handlers/' + handler, JSON.stringify(data))
+        .then(res => {
+            store.dispatch(updateGenerated(res.data));
         })
         .catch(err => {
             // TODO: make sure this clears.

--- a/src/features/schema/Schema.jsx
+++ b/src/features/schema/Schema.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import refreshSchema from './actions';
 import Field from './Field';
+import Generated from './fields/Generated';
 
 
 export default function Schema() {
@@ -14,9 +15,22 @@ export default function Schema() {
 
     return (
         <div>
-            {schema.value.schema.map((field) => {
-                return <Field key={field.id} field={field} />
-            })}
+            {
+                schema.value.schema.map((field) => {
+                    if (field.type === "generated") {
+                        return <Generated key={field.id} field={field} />
+                    }
+
+                    return <Field key={field.id} field={field} />
+                })
+            }
+            {
+                schema.generated.schema.map((field) => {
+                    // A generated field cannot return a generated field, that
+                    // would be chaos!
+                    return <Field key={field.id} field={field} />
+                })
+            }
         </div>
     );
 }

--- a/src/features/schema/fields/Generated.jsx
+++ b/src/features/schema/fields/Generated.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { callGeneratedHandler } from '../../handlers/actions';
+import { set as setError } from '../../errors/errorSlice';
+
+
+export default function Generated({ field }) {
+    const [source, setSource] = useState(null);
+    const config = useSelector(state => state.config);
+    const schema = useSelector(state => state.schema);
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        onChange(source);
+    }, [config])
+
+    useEffect(() => {
+        setSource(getSourceField());
+    }, [schema])
+
+    const onChange = (source_field) => {
+        if (source_field && source_field.id in config) {
+            callGeneratedHandler(field.id, field.handler, config[source_field.id].value);
+        }
+    }
+
+    const getSourceField = () => {
+        if (schema.value.schema.length == 0) {
+            return null;
+        }
+
+        for (let i = 0; i < schema.value.schema.length; i++) {
+            if (schema.value.schema[i].id === field.source) {
+                return schema.value.schema[i];
+            }
+        }
+
+        let msg = `schema.Generated references source that does not exist: ${field.source}`;
+        dispatch(setError({ id: msg, message: msg }));
+        return null;
+    }
+
+    return null;
+}

--- a/src/features/schema/schemaSlice.js
+++ b/src/features/schema/schemaSlice.js
@@ -9,10 +9,17 @@ export const schemaSlice = createSlice({
             version: '1',
             schema: []
         },
+        generated: {
+            version: '1',
+            schema: []
+        }
     },
     reducers: {
         update: (state = initialState, action) => {
             return { ...state, value: action.payload, loading: false, error: '' }
+        },
+        updateGenerated: (state = initialState, action) => {
+            return { ...state, generated: action.payload, loading: false, error: '' }
         },
         loading: (state = initialState, action) => {
             return { ...state, loading: action.payload }
@@ -23,5 +30,5 @@ export const schemaSlice = createSlice({
     },
 });
 
-export const { update, loading, error } = schemaSlice.actions;
+export const { update, updateGenerated, loading, error } = schemaSlice.actions;
 export default schemaSlice.reducer;


### PR DESCRIPTION
# Overview
We've had the generated field for some time, but it was undocumented and the devtools didn't support it. This change adds support and documentation for this field.

# About
This field is used to generate more schema fields based on user input. It's not straight forward to use, but it's really powerful. Internally, we use this most often to force a login before providing additional config parameters. For example, once a user has authenticated with Sonos, we then ask them which player they would like to select.

# Considerations
I noticed in this change that there are some pretty complicated bugs with error handling in the devtools. I decided to punt that to a latter change since it will require quite a bit more work. The downside is the error handling around generated fields and `source` not existing is a bit weird.

# Changes
- [feature: Add Generated support.](https://github.com/tidbyt/pixlet/commit/b9c7715e1d24ec49f177ff75f78ed58d72e7a459) 
    - This commit adds generated support to the devtools and documents the field.

# Preview
https://user-images.githubusercontent.com/3886576/179609636-a73ee044-b1e7-49b5-b721-fa071ad6ef08.mov


