### PR TITLE
feat(humanize): add url_encode, url_decode helpers

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -83,6 +83,9 @@ The `humanize` module has formatters for units to human friendly sizes.
 | `word_series(words, conjunction)` | Converts a list of words into a word series in English. It returns a string containing all the given words separated by commas, the coordinating conjunction, and a serial comma, as appropriate. |
 | `oxford_word_series(words, conjunction)` | Converts a list of words into a word series in English, using an [Oxford comma](https://en.wikipedia.org/wiki/Serial_comma). It returns a string containing all the given words separated by commas, the coordinating conjunction, and a serial comma, as appropriate. |
 
+| `url_encode(str)` | Escapes the string so it can be safely placed inside a URL query. |
+| `url_decode(str)` | The inverse of `url_encode`. Converts each 3-byte encoded substring of the form "%AB" into the hex-decoded byte 0xAB |
+
 Example:
 
 See [examples/humanize.star](../examples/humanize.star) for an example.

--- a/runtime/modules/humanize/humanize.go
+++ b/runtime/modules/humanize/humanize.go
@@ -3,6 +3,7 @@ package humanize
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"sync"
 	"time"
 
@@ -46,12 +47,54 @@ func LoadModule() (starlark.StringDict, error) {
 					"plural_word":        starlark.NewBuiltin("plural_word", pluralWord),
 					"word_series":        starlark.NewBuiltin("word_series", wordSeries),
 					"oxford_word_series": starlark.NewBuiltin("oxford_word_series", oxfordWordSeries),
+					"url_encode":         starlark.NewBuiltin("url_encode", urlEncode),
+					"url_decode":         starlark.NewBuiltin("url_decode", urlDecode),
 				},
 			},
 		}
 	})
 
 	return module, nil
+}
+
+func urlEncode(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		starUrl starlark.String
+	)
+
+	if err := starlark.UnpackArgs(
+		"url_encode",
+		args, kwargs,
+		"str", &starUrl,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for bytes: %s", err)
+	}
+
+	escapedUrl := url.QueryEscape(starUrl.GoString())
+
+	return starlark.String(escapedUrl), nil
+}
+
+func urlDecode(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		starUrl starlark.String
+	)
+
+	if err := starlark.UnpackArgs(
+		"url_decode",
+		args, kwargs,
+		"str", &starUrl,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for bytes: %s", err)
+	}
+
+	unescapedUrl, decodeErr := url.QueryUnescape(starUrl.GoString())
+
+	if decodeErr != nil {
+		return nil, fmt.Errorf("unable to decode url: %s: %s", starUrl.GoString(), decodeErr)
+	}
+
+	return starlark.String(unescapedUrl), nil
 }
 
 func times(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/runtime/modules/humanize/humanize_test.go
+++ b/runtime/modules/humanize/humanize_test.go
@@ -42,6 +42,8 @@ humanized_plural_word = humanize.plural_word(1, "star", "")
 humanized_word_series = humanize.word_series(["foo", "bar", "baz"], "and")
 humanized_word_series_oxford = humanize.oxford_word_series(["foo", "bar", "baz"], "and")
 iso_date = now.format(humanized_date_format)
+humanized_url_encode = humanize.url_encode("bar baz")
+humanized_url_decode = humanize.url_decode("http://example.com/foo=bar+baz")
 
 # Assert.
 assert(humanized_time_past == "2 days ago")
@@ -65,6 +67,8 @@ assert(humanized_plural_test == "1 star")
 assert(humanized_plural_word == "star")
 assert(humanized_word_series == "foo, bar and baz")
 assert(humanized_word_series_oxford == "foo, bar, and baz")
+assert(humanized_url_encode == "bar+baz")
+assert(humanized_url_decode == "http://example.com/foo=bar baz")
 
 def main():
 	return []


### PR DESCRIPTION
This PR adds two helper methods to the `humanize` module:

* `url_encode(str)` - Escapes the string so it can be safely placed inside a URL query. 
* `url_decode(str)` - The inverse of `url_encode`. Converts each 3-byte encoded substring of the form "%AB" into the hex-decoded byte 0xAB.