### PR TITLE
Add profiler command

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
+	pprof_driver "github.com/google/pprof/driver"
+	pprof_profile "github.com/google/pprof/profile"
 	"github.com/spf13/cobra"
 	"go.starlark.net/starlark"
 
@@ -13,19 +17,52 @@ import (
 )
 
 var (
-	profileOutput string
+	pprof_cmd string
 )
 
 func init() {
-	ProfileCmd.Flags().StringVarP(&profileOutput, "profile", "p", "", "Path for gzipped pprof output")
+	ProfileCmd.Flags().StringVarP(
+		&pprof_cmd, "pprof", "", "top 10", "Command to call pprof with",
+	)
 }
 
 var ProfileCmd = &cobra.Command{
 	Use:   "profile [script] [<key>=value>]...",
-	Short: "Runs script with provided config parameters and prints execution-time profile. See https://github.com/google/pprof for how to read the output.",
+	Short: "Runs script with provided config parameters and prints execution-time profile.",
 	Args:  cobra.MinimumNArgs(1),
 	Run:   profile,
 }
+
+// We save the profile into an in-memory buffer, which is simpler than the tool expects.
+// Simple adapter to pipe it through.
+type FetchFunc func(src string, duration, timeout time.Duration) (*pprof_profile.Profile, string, error)
+
+func (f FetchFunc) Fetch(src string, duration, timeout time.Duration) (*pprof_profile.Profile, string, error) {
+	return f(src, duration, timeout)
+}
+func MakeFetchFunc(prof *pprof_profile.Profile) FetchFunc {
+	return func(src string, duration, timeout time.Duration) (*pprof_profile.Profile, string, error) {
+		return prof, "", nil
+	}
+}
+
+// Calls the pprof program to print the top users of CPU, then exit
+type printUI struct{}
+
+var pprof_printed = false
+
+func (u printUI) ReadLine(prompt string) (string, error) {
+	if pprof_printed {
+		os.Exit(0)
+	}
+	pprof_printed = true
+	return pprof_cmd, nil
+}
+func (u printUI) Print(args ...interface{})                    {}
+func (u printUI) PrintErr(args ...interface{})                 {}
+func (u printUI) IsTerminal() bool                             { return false }
+func (u printUI) WantBrowser() bool                            { return false }
+func (u printUI) SetAutoComplete(complete func(string) string) {}
 
 func profile(cmd *cobra.Command, args []string) {
 	script := args[0]
@@ -60,18 +97,8 @@ func profile(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	outPath := strings.TrimSuffix(script, ".star") + "_pprof.gz"
-	if profileOutput != "" {
-		outPath = profileOutput
-	}
-	prof, err := os.Create(outPath)
-	if err != nil {
-		fmt.Printf("Cannot create temp file for output: %s", err)
-		os.Exit(1)
-	}
-	defer prof.Close()
-
-	if err = starlark.StartProfile(prof); err != nil {
+	buf := new(bytes.Buffer)
+	if err = starlark.StartProfile(buf); err != nil {
 		fmt.Printf("Error starting profiler: %s\n", err)
 		os.Exit(1)
 	}
@@ -87,5 +114,19 @@ func profile(cmd *cobra.Command, args []string) {
 		fmt.Printf("Error stopping profiler: %s\n", err)
 		os.Exit(1)
 	}
-	prof.Sync()
+
+	profile, err := pprof_profile.ParseData(buf.Bytes())
+	if err != nil {
+		fmt.Printf("Could not parse pprof profile: %s\n", err)
+		os.Exit(1)
+	}
+
+	options := &pprof_driver.Options{
+		Fetch: MakeFetchFunc(profile),
+		UI:    printUI{},
+	}
+	if err = pprof_driver.PProf(options); err != nil {
+		fmt.Printf("Could not start pprof driver: %s\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.starlark.net/starlark"
+
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var (
+	profileOutput string
+)
+
+func init() {
+	ProfileCmd.Flags().StringVarP(&profileOutput, "profile", "p", "", "Path for gzipped pprof output")
+}
+
+var ProfileCmd = &cobra.Command{
+	Use:   "profile [script] [<key>=value>]...",
+	Short: "Runs script with provided config parameters and prints execution-time profile. See https://github.com/google/pprof for how to read the output.",
+	Args:  cobra.MinimumNArgs(1),
+	Run:   profile,
+}
+
+func profile(cmd *cobra.Command, args []string) {
+	script := args[0]
+
+	if !strings.HasSuffix(script, ".star") {
+		fmt.Printf("script file must have suffix .star: %s\n", script)
+		os.Exit(1)
+	}
+
+	config := map[string]string{}
+	for _, param := range args[1:] {
+		split := strings.Split(param, "=")
+		if len(split) != 2 {
+			fmt.Printf("parameters must be on form <key>=<value>, found %s\n", param)
+			os.Exit(1)
+		}
+		config[split[0]] = split[1]
+	}
+
+	src, err := ioutil.ReadFile(script)
+	if err != nil {
+		fmt.Printf("failed to read file %s: %v\n", script, err)
+		os.Exit(1)
+	}
+
+	runtime.InitCache(runtime.NewInMemoryCache())
+
+	applet := runtime.Applet{}
+	err = applet.Load(script, src, nil)
+	if err != nil {
+		fmt.Printf("failed to load applet: %v\n", err)
+		os.Exit(1)
+	}
+
+	outPath := strings.TrimSuffix(script, ".star") + "_pprof.gz"
+	if profileOutput != "" {
+		outPath = profileOutput
+	}
+	prof, err := os.Create(outPath)
+	if err != nil {
+		fmt.Printf("Cannot create temp file for output: %s", err)
+		os.Exit(1)
+	}
+	defer prof.Close()
+
+	if err = starlark.StartProfile(prof); err != nil {
+		fmt.Printf("Error starting profiler: %s\n", err)
+		os.Exit(1)
+	}
+
+	_, err = applet.Run(config)
+	if err != nil {
+		_ = starlark.StopProfile()
+		fmt.Printf("Error running script: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err = starlark.StopProfile(); err != nil {
+		fmt.Printf("Error stopping profiler: %s\n", err)
+		os.Exit(1)
+	}
+	prof.Sync()
+}

--- a/docs/authoring_apps.md
+++ b/docs/authoring_apps.md
@@ -88,3 +88,13 @@ For example, if your app receives an error from an external API, try these optio
 [2]: https://github.com/bazelbuild/starlark/blob/master/spec.md#print
 [3]: https://github.com/tidbyt/community
 [4]: schema/schema.md
+
+## Performance profiling
+
+Some apps may take a long time to render, particularly if they produce a long and complex animation. You can use `pixlet profile` to identify how to optimize the app's performance. Most apps will not need this kind of optimization.
+
+```shell
+$ pixlet profile path_to_your_app.star
+```
+
+When you profile your app, it will print a list of the functions which consume the most CPU time. Improving these will have the biggest impact on overall run time.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fogleman/gg v1.3.0
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/go-playground/validator/v10 v10.11.0
+	github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57
 	github.com/google/tink/go v1.4.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
@@ -42,6 +43,7 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.1 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
+github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57 h1:eqyIo2HjKhKe/mJzTG8n4VqvLXIOEG+SLdDqX7xGtkY=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -298,6 +299,8 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c h1:rwmN+hgiyp8QyBqzdEX43lTjKAxaqCrYHaU5op5P9J8=
+github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func init() {
 	rootCmd.AddCommand(cmd.PushCmd)
 	rootCmd.AddCommand(cmd.EncryptCmd)
 	rootCmd.AddCommand(cmd.VersionCmd)
+	rootCmd.AddCommand(cmd.ProfileCmd)
 }
 
 func main() {


### PR DESCRIPTION
To help investigate performance issues mentioned in https://github.com/tidbyt/community/pull/560

Based on the render command and the example given here: https://github.com/google/starlark-go/blob/master/starlark/profile_test.go

You give the command. It runs the profile and prints an output table. Pretty neat!

Example usage and output:

```
$ ./pixlet profile ../tidbyt-community/apps/life/life.star

Type: wall
Time: Aug 5, 2022 at 9:13pm (BST)
Duration: 3.60s, Total samples = 3.21s (89.18%)
Showing nodes accounting for 3.21s, 100% of 3.21s total
      flat  flat%   sum%        cum   cum%
     1.37s 42.68% 42.68%      2.17s 67.60%  count_living_neighbours
     0.39s 12.15% 54.83%      0.39s 12.15%  next_col
     0.36s 11.21% 66.04%      0.36s 11.21%  Box
     0.34s 10.59% 76.64%      0.79s 24.61%  render_board
     0.23s  7.17% 83.80%      0.23s  7.17%  prev_col
     0.20s  6.23% 90.03%      2.37s 73.83%  next_state
     0.13s  4.05% 94.08%      0.13s  4.05%  prev_row
     0.07s  2.18% 96.26%      0.07s  2.18%  append
     0.05s  1.56% 97.82%      2.42s 75.39%  next_board
     0.05s  1.56% 99.38%      0.05s  1.56%  next_row
     0.02s  0.62%   100%      0.02s  0.62%  Row
         0     0%   100%      3.21s   100%  animate
         0     0%   100%      3.21s   100%  main
```