### PR TITLE
perf: Use shared drawing context

### DIFF
--- a/render/animation.go
+++ b/render/animation.go
@@ -2,6 +2,8 @@ package render
 
 import (
 	"image"
+
+	"github.com/fogleman/gg"
 )
 
 // Animations turns a list of children into an animation, where each
@@ -32,7 +34,7 @@ func (a Animation) FrameCount() int {
 	return len(a.Children)
 }
 
-func (a Animation) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (a Animation) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
 	if frameIdx > len(a.Children) {
 		frameIdx %= len(a.Children)
 		if frameIdx < 0 {
@@ -40,5 +42,16 @@ func (a Animation) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		}
 	}
 
-	return a.Children[ModInt(frameIdx, len(a.Children))].Paint(bounds, frameIdx)
+	return a.Children[ModInt(frameIdx, len(a.Children))].PaintBounds(bounds, frameIdx)
+}
+
+func (a Animation) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	if frameIdx > len(a.Children) {
+		frameIdx %= len(a.Children)
+		if frameIdx < 0 {
+			frameIdx += len(a.Children)
+		}
+	}
+
+	a.Children[ModInt(frameIdx, len(a.Children))].Paint(dc, bounds, frameIdx)
 }

--- a/render/animation/positioned.go
+++ b/render/animation/positioned.go
@@ -36,7 +36,11 @@ type AnimatedPositioned struct {
 	Hold     int           `starlark:"hold"`
 }
 
-func (o AnimatedPositioned) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (o AnimatedPositioned) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
+	return bounds
+}
+
+func (o AnimatedPositioned) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 	var position float64
 
 	if frameIdx < o.Delay {
@@ -62,11 +66,10 @@ func (o AnimatedPositioned) Paint(bounds image.Rectangle, frameIdx int) image.Im
 	x := o.XStart + dx*sx
 	y := o.YStart + dy*sy
 
-	im := o.Child.Paint(bounds, frameIdx)
-
-	dc := gg.NewContext(bounds.Dx(), bounds.Dy())
-	dc.DrawImage(im, x, y)
-	return dc.Image()
+	dc.Push()
+	dc.Translate(float64(x), float64(y))
+	o.Child.Paint(dc, bounds, frameIdx)
+	dc.Pop()
 }
 
 func (o AnimatedPositioned) FrameCount() int {

--- a/render/animation/positioned_test.go
+++ b/render/animation/positioned_test.go
@@ -30,7 +30,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 
 	assert.Equal(t, 6, o.FrameCount())
 
-	im := o.Paint(image.Rect(0, 0, 10, 6), 0)
+	im := render.PaintWidget(o, image.Rect(0, 0, 10, 6), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrrr......",
 		"rrrr......",
@@ -40,7 +40,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		".rrrr.....",
@@ -50,7 +50,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -60,7 +60,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 3)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -71,7 +71,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 	}, im))
 
 	// These last two frames, the rectangle moves out of bounds.
-	im = o.Paint(image.Rect(0, 0, 10, 6), 4)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 4)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -81,7 +81,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 		"....rrrr..",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 5)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 5)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -93,7 +93,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 
 	// For now, the behavior for later frames is to freeze the
 	// final frame, i.e. keep child at the end position.
-	im = o.Paint(image.Rect(0, 0, 10, 6), 6)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 6)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -102,7 +102,7 @@ func TestPositionedLinearCurve(t *testing.T) {
 		"..........",
 		".....rrrr.",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 10, 6), 7)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 7)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -132,7 +132,7 @@ func TestPositionedEaseIn(t *testing.T) {
 	// A green box appearing from off screen, moving rapidly at
 	// first, then decelerating into its end position.
 
-	im := o.Paint(image.Rect(0, 0, 10, 4), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -140,7 +140,7 @@ func TestPositionedEaseIn(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 4), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		".gg.......",
@@ -148,7 +148,7 @@ func TestPositionedEaseIn(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 4), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..gg......",
@@ -156,7 +156,7 @@ func TestPositionedEaseIn(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 4), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 3)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"...gg.....",
@@ -164,7 +164,7 @@ func TestPositionedEaseIn(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 4), 4)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 4)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"...gg.....",
@@ -172,7 +172,7 @@ func TestPositionedEaseIn(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 4), 5)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 5)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"....gg....",
@@ -180,7 +180,7 @@ func TestPositionedEaseIn(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 4), 9)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 4), 9)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"....gg....",
@@ -212,57 +212,57 @@ func TestPositionedDelayAndHold(t *testing.T) {
 	assert.Equal(t, 10, o.FrameCount())
 
 	// No movement during delay
-	im := o.Paint(image.Rect(0, 0, 5, 2), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"g....",
 		"g....",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 5, 2), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"g....",
 		"g....",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"g....",
 		"g....",
 	}, im))
 
 	// After that, linear motion to XEnd=4
-	im = o.Paint(image.Rect(0, 0, 5, 2), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 3)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"g....",
 		"g....",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 4)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 4)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".g...",
 		".g...",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 5)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 5)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..g..",
 		"..g..",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 6)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 6)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"...g.",
 		"...g.",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 7)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 7)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"....g",
 		"....g",
 	}, im))
 
 	// Final frame is held
-	im = o.Paint(image.Rect(0, 0, 5, 2), 8)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 8)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"....g",
 		"....g",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 9)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 9)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"....g",
 		"....g",
@@ -270,12 +270,12 @@ func TestPositionedDelayAndHold(t *testing.T) {
 
 	// Requesting frames beyond FrameCount() returns final frame
 	// as well
-	im = o.Paint(image.Rect(0, 0, 5, 2), 10)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 10)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"....g",
 		"....g",
 	}, im))
-	im = o.Paint(image.Rect(0, 0, 5, 2), 101212)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 2), 101212)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"....g",
 		"....g",
@@ -309,7 +309,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 
 	assert.Equal(t, 8, o.FrameCount())
 
-	im := o.Paint(image.Rect(0, 0, 10, 6), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -319,7 +319,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 		"rr........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -329,7 +329,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 		"g.........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -339,7 +339,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 		".rr.......",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 3)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"..........",
 		"..........",
@@ -350,7 +350,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 	}, im))
 
 	// fast forward to the end
-	im = o.Paint(image.Rect(0, 0, 10, 6), 6)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 6)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....rr...",
 		".....rr...",
@@ -360,7 +360,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 7)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 7)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....g....",
 		"..........",
@@ -371,7 +371,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 	}, im))
 
 	// past final frame, and past hold, animation still runs
-	im = o.Paint(image.Rect(0, 0, 10, 6), 8)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 8)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....rr...",
 		".....rr...",
@@ -381,7 +381,7 @@ func TestPositionedChildAnimation(t *testing.T) {
 		"..........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 10, 6), 9)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 10, 6), 9)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....g....",
 		"..........",

--- a/render/animation/transformation_test.go
+++ b/render/animation/transformation_test.go
@@ -48,7 +48,7 @@ func TestTransformationTranslate(t *testing.T) {
 	// These frames should show the box moving diagonally out of frame.
 	assert.Equal(t, 6, o.FrameCount())
 
-	im := o.Paint(image.Rect(0, 0, 5, 5), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrr..",
 		"ggg..",
@@ -57,7 +57,7 @@ func TestTransformationTranslate(t *testing.T) {
 		".....",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 5, 5), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 5), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....",
 		".rrr.",
@@ -66,7 +66,7 @@ func TestTransformationTranslate(t *testing.T) {
 		".....",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 5, 5), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 5), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....",
 		".....",
@@ -75,7 +75,7 @@ func TestTransformationTranslate(t *testing.T) {
 		"..bbb",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 5, 5), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 5), 3)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....",
 		".....",
@@ -84,7 +84,7 @@ func TestTransformationTranslate(t *testing.T) {
 		"...gg",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 5, 5), 4)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 5), 4)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....",
 		".....",
@@ -93,7 +93,7 @@ func TestTransformationTranslate(t *testing.T) {
 		"....r",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 5, 5), 5)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 5, 5), 5)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		".....",
 		".....",
@@ -144,7 +144,7 @@ func TestTransformationScale(t *testing.T) {
 	// These frames should show the box scaling from 1x to 3x.
 	assert.Equal(t, 3, o.FrameCount())
 
-	im := o.Paint(image.Rect(0, 0, 9, 9), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 9, 9), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrr......",
 		"rrr......",
@@ -157,7 +157,7 @@ func TestTransformationScale(t *testing.T) {
 		".........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 9, 9), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 9, 9), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrrrrr...",
 		"rrrrrr...",
@@ -170,7 +170,7 @@ func TestTransformationScale(t *testing.T) {
 		".........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 9, 9), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 9, 9), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrrrrrrrr",
 		"rrrrrrrrr",
@@ -224,35 +224,35 @@ func TestTransformationRotate(t *testing.T) {
 	// These frames should show the box rotating 90 degrees each frame.
 	assert.Equal(t, 5, o.FrameCount())
 
-	im := o.Paint(image.Rect(0, 0, 3, 3), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 0)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrr",
 		"ggg",
 		"bbb",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 1)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"bgr",
 		"bgr",
 		"bgr",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 2)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"bbb",
 		"ggg",
 		"rrr",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 3)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rgb",
 		"rgb",
 		"rgb",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 4)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 4)
 	assert.Equal(t, nil, render.CheckImage([]string{
 		"rrr",
 		"ggg",
@@ -264,14 +264,16 @@ func TestTransformationAll(t *testing.T) {
 	// Checking colors with anti-aliasing (when scaling) is more complex.
 	ic := render.ImageChecker{Palette: map[string]color.RGBA{
 		"█": {0xff, 0xff, 0xff, 0xff},
-		"▓": {0x80, 0x80, 0x80, 0x80},
-		"▒": {0x7f, 0x7f, 0x7f, 0x7f},
-		"░": {0x40, 0x40, 0x40, 0x40},
+		"▓": {0x40, 0x40, 0x40, 0x40},
+		"▒": {0x20, 0x20, 0x20, 0x20},
+		"░": {0x08, 0x08, 0x08, 0x08},
+		"⎕": {0x04, 0x04, 0x04, 0x04},
 		".": {0, 0, 0, 0},
 		"●": {0, 0, 0, 0xff},
-		"◉": {0, 0, 0, 0x80},
-		"◎": {0, 0, 0, 0x7f},
-		"○": {0, 0, 0, 0x40},
+		"◉": {0, 0, 0, 0x40},
+		"◎": {0, 0, 0, 0x20},
+		"○": {0, 0, 0, 0x08},
+		"⁘": {0, 0, 0, 0x04},
 	}}
 
 	o := Transformation{
@@ -342,7 +344,7 @@ func TestTransformationAll(t *testing.T) {
 	// translated, rotated and in the end scaled to 2x.
 	assert.Equal(t, 5, o.FrameCount())
 
-	im := o.Paint(image.Rect(0, 0, 9, 9), 0)
+	im := render.PaintWidget(&o, image.Rect(0, 0, 9, 9), 0)
 	assert.Equal(t, nil, ic.Check([]string{
 		"█.●......",
 		".........",
@@ -355,7 +357,7 @@ func TestTransformationAll(t *testing.T) {
 		".........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 9, 9), 1)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 9, 9), 1)
 	assert.Equal(t, nil, ic.Check([]string{
 		".........",
 		".●.█.....",
@@ -368,7 +370,7 @@ func TestTransformationAll(t *testing.T) {
 		".........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 2)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 2)
 	assert.Equal(t, nil, ic.Check([]string{
 		".........",
 		".........",
@@ -381,7 +383,7 @@ func TestTransformationAll(t *testing.T) {
 		".........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 3)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 3)
 	assert.Equal(t, nil, ic.Check([]string{
 		".........",
 		".........",
@@ -394,17 +396,17 @@ func TestTransformationAll(t *testing.T) {
 		".........",
 	}, im))
 
-	im = o.Paint(image.Rect(0, 0, 3, 3), 4)
+	im = render.PaintWidget(&o, image.Rect(0, 0, 3, 3), 4)
 
 	assert.Equal(t, nil, ic.Check([]string{
 		".........",
 		".........",
-		"..░▓░.○◉○",
-		"..▓█▓.◉●◎",
-		"..░▓░.○◉○",
+		"..⎕▒░.○◎⁘",
+		"..▒█▓.◉●◎",
+		"..⎕▒░.○◎⁘",
 		".........",
-		"..○◎○.░▓░",
-		"..◎●◉.▓█▓",
-		"..○◎○.░▓░",
+		"..⁘◎○.░▒⎕",
+		"..◎●◉.▓█▒",
+		"..⁘◎○.░▒⎕",
 	}, im))
 }

--- a/render/box_test.go
+++ b/render/box_test.go
@@ -13,7 +13,7 @@ func TestBoxNoChild(t *testing.T) {
 
 	// Transparent by default
 	box := Box{}
-	im := box.Paint(image.Rect(0, 0, 5, 5), 0)
+	im := PaintWidget(box, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
 		".....",
@@ -24,7 +24,7 @@ func TestBoxNoChild(t *testing.T) {
 
 	// Color can be set
 	box = Box{Color: color.RGBA{0xff, 0, 0, 0xff}}
-	im = box.Paint(image.Rect(0, 0, 5, 5), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrr",
 		"rrrrr",
@@ -35,7 +35,7 @@ func TestBoxNoChild(t *testing.T) {
 
 	// Specify Width and the box fills height bounds
 	box = Box{Color: color.RGBA{0xff, 0, 0, 0xff}, Width: 3}
-	im = box.Paint(image.Rect(0, 0, 5, 5), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr",
 		"rrr",
@@ -46,7 +46,7 @@ func TestBoxNoChild(t *testing.T) {
 
 	// Specify Height and it fills width bounds
 	box = Box{Color: color.RGBA{0xff, 0, 0, 0xff}, Height: 3}
-	im = box.Paint(image.Rect(0, 0, 5, 5), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrr",
 		"rrrrr",
@@ -55,7 +55,7 @@ func TestBoxNoChild(t *testing.T) {
 
 	// Specify both and it ignores the bounds entirely
 	box = Box{Color: color.RGBA{0xff, 0, 0, 0xff}, Width: 2, Height: 3}
-	im = box.Paint(image.Rect(0, 0, 5, 5), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rr",
 		"rr",
@@ -73,7 +73,7 @@ func TestBoxChildCenter(t *testing.T) {
 			Height: 2,
 		},
 	}
-	im := box.Paint(image.Rect(0, 0, 4, 4), 0)
+	im := PaintWidget(box, image.Rect(0, 0, 4, 4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....",
 		".rr.",
@@ -83,7 +83,7 @@ func TestBoxChildCenter(t *testing.T) {
 
 	// If perfect centering can be done, remaining pixels are on
 	// the right and below the child.
-	im = box.Paint(image.Rect(0, 0, 5, 5), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 5, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
 		".rr..",
@@ -93,14 +93,14 @@ func TestBoxChildCenter(t *testing.T) {
 	}, im))
 
 	// Centered horizontally here
-	im = box.Paint(image.Rect(0, 0, 4, 2), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 4, 2), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rr.",
 		".rr.",
 	}, im))
 
 	// Centered vertically here
-	im = box.Paint(image.Rect(0, 0, 2, 4), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 2, 4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..",
 		"rr",
@@ -117,7 +117,7 @@ func TestBoxPadding(t *testing.T) {
 			Color: color.RGBA{0xff, 0, 0, 0xff},
 		},
 	}
-	im := box.Paint(image.Rect(0, 0, 4, 4), 0)
+	im := PaintWidget(box, image.Rect(0, 0, 4, 4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr",
 		"rrrr",
@@ -132,7 +132,7 @@ func TestBoxPadding(t *testing.T) {
 		},
 		Padding: 1,
 	}
-	im = box.Paint(image.Rect(0, 0, 4, 4), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 4, 4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....",
 		".rr.",
@@ -147,7 +147,7 @@ func TestBoxPadding(t *testing.T) {
 		},
 		Padding: 3,
 	}
-	im = box.Paint(image.Rect(0, 0, 8, 8), 0)
+	im = PaintWidget(box, image.Rect(0, 0, 8, 8), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",

--- a/render/column.go
+++ b/render/column.go
@@ -2,6 +2,8 @@ package render
 
 import (
 	"image"
+
+	"github.com/fogleman/gg"
 )
 
 // Column lays out and draws its children vertically (in a column).
@@ -62,7 +64,7 @@ type Column struct {
 	Expanded   bool
 }
 
-func (c Column) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (c Column) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
 	v := Vector{
 		Vertical:   true,
 		Children:   c.Children,
@@ -70,7 +72,18 @@ func (c Column) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		CrossAlign: c.CrossAlign,
 		Expanded:   c.Expanded,
 	}
-	return v.Paint(bounds, frameIdx)
+	return v.PaintBounds(bounds, frameIdx)
+}
+
+func (c Column) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	v := Vector{
+		Vertical:   true,
+		Children:   c.Children,
+		MainAlign:  c.MainAlign,
+		CrossAlign: c.CrossAlign,
+		Expanded:   c.Expanded,
+	}
+	v.Paint(dc, bounds, frameIdx)
 }
 
 func (c Column) FrameCount() int {

--- a/render/column_test.go
+++ b/render/column_test.go
@@ -25,7 +25,7 @@ func TestColumnPaint(t *testing.T) {
 
 	// On large canvas, height gets truncated to max of children,
 	// while width expands to full size
-	im := c.Paint(image.Rect(0, 0, 25, 16+3), 0)
+	im := PaintWidget(c, image.Rect(0, 0, 25, 16+3), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		".gggggg.",

--- a/render/image.go
+++ b/render/image.go
@@ -11,6 +11,7 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 
+	"github.com/fogleman/gg"
 	"github.com/nfnt/resize"
 	"github.com/tidbyt/go-libwebp/webp"
 )
@@ -39,8 +40,12 @@ type Image struct {
 	imgs []image.Image
 }
 
-func (p *Image) Paint(bounds image.Rectangle, frameIdx int) image.Image {
-	return p.imgs[ModInt(frameIdx, len(p.imgs))]
+func (p *Image) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
+	return p.imgs[ModInt(frameIdx, len(p.imgs))].Bounds()
+}
+
+func (p *Image) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	dc.DrawImage(p.imgs[ModInt(frameIdx, len(p.imgs))], 0, 0)
 }
 
 func (p *Image) Size() (int, int) {

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -18,7 +18,7 @@ func TestImage(t *testing.T) {
 	img.Init()
 
 	// Size of Image is independent of bounds
-	im := img.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(img, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrr",
 		"r........r",
@@ -37,7 +37,7 @@ func TestImage(t *testing.T) {
 	assert.Equal(t, 10, w)
 	assert.Equal(t, 12, h)
 
-	im = img.Paint(image.Rect(0, 0, 100, 100), 0)
+	im = PaintWidget(img, image.Rect(0, 0, 100, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrr",
 		"r........r",
@@ -67,7 +67,7 @@ func TestImageScale(t *testing.T) {
 	w, h := img.Size()
 	assert.Equal(t, 5, w)
 	assert.Equal(t, 6, h)
-	im := img.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(img, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, 5, im.Bounds().Dx())
 	assert.Equal(t, 6, im.Bounds().Dy())
 }
@@ -83,7 +83,7 @@ func TestImageScaleAspectRatioWidth(t *testing.T) {
 	w, h := img.Size()
 	assert.Equal(t, 5, w)
 	assert.Equal(t, 6, h)
-	im := img.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(img, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, 5, im.Bounds().Dx())
 	assert.Equal(t, 6, im.Bounds().Dy())
 }
@@ -99,7 +99,7 @@ func TestImageScaleAspectRatioHeight(t *testing.T) {
 	w, h := img.Size()
 	assert.Equal(t, 5, w)
 	assert.Equal(t, 6, h)
-	im := img.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(img, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, 5, im.Bounds().Dx())
 	assert.Equal(t, 6, im.Bounds().Dy())
 }
@@ -137,7 +137,7 @@ func TestImageAnimatedGif(t *testing.T) {
 		"x....",
 		".x...",
 		"...x.",
-	}, img.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 0)))
 
 	// since no disposal method is set, subsequent frames should
 	// draw on top of first frame
@@ -146,19 +146,19 @@ func TestImageAnimatedGif(t *testing.T) {
 		"xx...",
 		".xx..",
 		"...xx",
-	}, img.Paint(image.Rect(0, 0, 100, 100), 1)))
+	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 1)))
 	assert.Equal(t, nil, checkImage([]string{
 		"x.xxx",
 		"xxx..",
 		".xxx.",
 		"...xx",
-	}, img.Paint(image.Rect(0, 0, 100, 100), 2)))
+	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 2)))
 	assert.Equal(t, nil, checkImage([]string{
 		"xxxxx",
 		"xxxx.",
 		".xxxx",
 		"...xx",
-	}, img.Paint(image.Rect(0, 0, 100, 100), 3)))
+	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 3)))
 
 	// loops after the last frame
 	assert.Equal(t, nil, checkImage([]string{
@@ -166,11 +166,11 @@ func TestImageAnimatedGif(t *testing.T) {
 		"x....",
 		".x...",
 		"...x.",
-	}, img.Paint(image.Rect(0, 0, 100, 100), 4)))
+	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 4)))
 	assert.Equal(t, nil, checkImage([]string{
 		"..xx.",
 		"xx...",
 		".xx..",
 		"...xx",
-	}, img.Paint(image.Rect(0, 0, 100, 100), 5)))
+	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 5)))
 }

--- a/render/marquee_test.go
+++ b/render/marquee_test.go
@@ -35,8 +35,8 @@ func TestMarqueeNoScrollHorizontal(t *testing.T) {
 	// Child fits so there's just 1 single frame
 	assert.Equal(t, 1, m.FrameCount())
 	assert.Equal(t, 1, mv.FrameCount())
-	im := m.Paint(image.Rect(0, 0, 100, 100), 0)
-	imv := mv.Paint(image.Rect(0, 0, 100, 100), 0)
+	im := PaintWidget(m, image.Rect(0, 0, 100, 100), 0)
+	imv := PaintWidget(mv, image.Rect(0, 0, 100, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrggb",
 		"rrrgg.",
@@ -78,8 +78,8 @@ func TestMarqueeNoScrollAlignCenter(t *testing.T) {
 	// Child fits so there's just 1 single frame
 	assert.Equal(t, 1, m.FrameCount())
 	assert.Equal(t, 1, mv.FrameCount())
-	im := m.Paint(image.Rect(0, 0, 100, 100), 0)
-	imv := mv.Paint(image.Rect(0, 0, 100, 100), 0)
+	im := PaintWidget(m, image.Rect(0, 0, 100, 100), 0)
+	imv := PaintWidget(mv, image.Rect(0, 0, 100, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rrrggb.",
 		".rrrgg..",
@@ -123,8 +123,8 @@ func TestMarqueeNoScrollAlignEnd(t *testing.T) {
 	// Child fits so there's just 1 single frame
 	assert.Equal(t, 1, m.FrameCount())
 	assert.Equal(t, 1, mv.FrameCount())
-	im := m.Paint(image.Rect(0, 0, 100, 100), 0)
-	imv := mv.Paint(image.Rect(0, 0, 100, 100), 0)
+	im := PaintWidget(m, image.Rect(0, 0, 100, 100), 0)
+	imv := PaintWidget(mv, image.Rect(0, 0, 100, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrrggb",
 		"..rrrgg.",
@@ -166,51 +166,51 @@ func TestMarqueeOldBehavior(t *testing.T) {
 		"......",
 		"......",
 		"......",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 0)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"....rr",
 		"....rr",
 		"....rr",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 2)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 2)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrggg",
 		"rrrggg",
 		"rrr...",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 6)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 6)))
 
 	// Scrolling out of view
 	assert.Equal(t, nil, checkImage([]string{
 		"rgggbb",
 		"rggg..",
 		"r.....",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 8)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 8)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"b.....",
 		"......",
 		"......",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 14)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 14)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"......",
 		"......",
 		"......",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 15)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 15)))
 
 	// Scrolling back into view
 	assert.Equal(t, nil, checkImage([]string{
 		"...rrr",
 		"...rrr",
 		"...rrr",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 18)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 18)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrggg",
 		"rrrggg",
 		"rrr...",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 21)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 21)))
 
 	// Later frames keep it fixed in the last frame. This makes
 	// multiple simultaneous marquees look nice when they've
@@ -220,19 +220,19 @@ func TestMarqueeOldBehavior(t *testing.T) {
 		"rrrggg",
 		"rrrggg",
 		"rrr...",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 22)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 22)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrggg",
 		"rrrggg",
 		"rrr...",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 26)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 26)))
 
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrggg",
 		"rrrggg",
 		"rrr...",
-	}, m.Paint(image.Rect(0, 0, 100, 100), 100000)))
+	}, PaintWidget(m, image.Rect(0, 0, 100, 100), 100000)))
 }
 
 func TestMarqueeOffsetIdentical(t *testing.T) {
@@ -251,36 +251,36 @@ func TestMarqueeOffsetIdentical(t *testing.T) {
 
 	// Check that identical frames are not repeated after
 	// another, if start and end offset are identical.
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{"bb...."}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{"....rg"}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{"...rgg"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 11)))
-	assert.Equal(t, nil, checkImage([]string{".rggbb"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"bb...."}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"....rg"}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"...rgg"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 11)))
+	assert.Equal(t, nil, checkImage([]string{".rggbb"}, PaintWidget(m, im, 12)))
 	assert.Equal(t, 13, m.FrameCount())
 
 	m.OffsetStart = 3
 	m.OffsetEnd = 3
-	assert.Equal(t, nil, checkImage([]string{"...rgg"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{".rggbb"}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{"bb...."}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 11)))
-	assert.Equal(t, nil, checkImage([]string{"....rg"}, m.Paint(im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"...rgg"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".rggbb"}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"bb...."}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"....rg"}, PaintWidget(m, im, 12)))
 	assert.Equal(t, 13, m.FrameCount())
 }
 
@@ -300,59 +300,59 @@ func TestMarqueeOffsetStart(t *testing.T) {
 
 	// OffsetStart affects the initial position of the child
 	m.OffsetStart = 2
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".rggbb"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{"bb...."}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".rggbb"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"bb...."}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 9)))
 
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{"....rg"}, m.Paint(im, 11)))
-	assert.Equal(t, nil, checkImage([]string{"...rgg"}, m.Paint(im, 12)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 13)))
-	assert.Equal(t, nil, checkImage([]string{".rggbb"}, m.Paint(im, 14)))
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 15)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"....rg"}, PaintWidget(m, im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"...rgg"}, PaintWidget(m, im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 13)))
+	assert.Equal(t, nil, checkImage([]string{".rggbb"}, PaintWidget(m, im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 15)))
 	assert.Equal(t, 16, m.FrameCount())
 
 	// Negative OffsetStart
 	m.OffsetStart = -2
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"bb...."}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{"....rg"}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{"...rgg"}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{".rggbb"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"bb...."}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"....rg"}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"...rgg"}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".rggbb"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 11)))
 	assert.Equal(t, 12, m.FrameCount())
 
 	// Overly negative OffsetStart is truncated to child width
 	m.OffsetStart = -1000
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"....rg"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"....rg"}, PaintWidget(m, im, 2)))
 	assert.Equal(t, 7, m.FrameCount())
 	m.OffsetStart = -7
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 1)))
 	assert.Equal(t, 7, m.FrameCount())
 	m.OffsetStart = -8
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 1)))
 	assert.Equal(t, 7, m.FrameCount())
 	m.OffsetStart = -6
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 2)))
 	assert.Equal(t, 8, m.FrameCount())
 }
 
@@ -372,62 +372,62 @@ func TestMarqueeOffsetEnd(t *testing.T) {
 
 	// OffsetEnd affects the final position of the child
 	m.OffsetEnd = 2
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{"bb...."}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{".....r"}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{"....rg"}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{"...rgg"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"bb...."}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".....r"}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"....rg"}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"...rgg"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 11)))
 	assert.Equal(t, 12, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 12)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 13)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 1024)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 13)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 1024)))
 
 	// Negative offset places child outside of marquee
 	m.OffsetEnd = -4
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"...rgg"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{"..rggb"}, m.Paint(im, 11)))
-	assert.Equal(t, nil, checkImage([]string{".rggbb"}, m.Paint(im, 12)))
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 13)))
-	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, m.Paint(im, 14)))
-	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, m.Paint(im, 15)))
-	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, m.Paint(im, 16)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 17)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"...rgg"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"..rggb"}, PaintWidget(m, im, 11)))
+	assert.Equal(t, nil, checkImage([]string{".rggbb"}, PaintWidget(m, im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 13)))
+	assert.Equal(t, nil, checkImage([]string{"ggbbbb"}, PaintWidget(m, im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"gbbbb."}, PaintWidget(m, im, 15)))
+	assert.Equal(t, nil, checkImage([]string{"bbbb.."}, PaintWidget(m, im, 16)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 17)))
 	assert.Equal(t, 18, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 18)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 19)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 1024)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 18)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 19)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 1024)))
 
 	// Very negative offset is truncated to width of child
 	m.OffsetEnd = -133
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"bbb..."}, m.Paint(im, 17)))
-	assert.Equal(t, nil, checkImage([]string{"bb...."}, m.Paint(im, 18)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 19)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 20)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"bbb..."}, PaintWidget(m, im, 17)))
+	assert.Equal(t, nil, checkImage([]string{"bb...."}, PaintWidget(m, im, 18)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 19)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 20)))
 	assert.Equal(t, 21, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 21)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 22)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 23)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 21)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 22)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 23)))
 
 	// OffsetEnd >= width means it doesn't scroll back
 	m.OffsetEnd = 6
-	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"b....."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"rggbbb"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"b....."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 7)))
 	assert.Equal(t, 8, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{"......"}, m.Paint(im, 1024)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{"......"}, PaintWidget(m, im, 1024)))
 
 }
 
@@ -455,7 +455,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		"g",
 		"g",
 		"b",
-	}, m.Paint(im, 0)))
+	}, PaintWidget(m, im, 0)))
 	assert.Equal(t, nil, checkImage([]string{
 		".",
 		"r",
@@ -463,7 +463,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		"g",
 		"b",
 		"b",
-	}, m.Paint(im, 1)))
+	}, PaintWidget(m, im, 1)))
 	assert.Equal(t, nil, checkImage([]string{
 		"r",
 		"g",
@@ -471,7 +471,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		"b",
 		"b",
 		"b",
-	}, m.Paint(im, 2)))
+	}, PaintWidget(m, im, 2)))
 	assert.Equal(t, nil, checkImage([]string{
 		"g",
 		"g",
@@ -479,7 +479,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		"b",
 		"b",
 		"b",
-	}, m.Paint(im, 3)))
+	}, PaintWidget(m, im, 3)))
 	assert.Equal(t, nil, checkImage([]string{
 		"g",
 		"b",
@@ -487,7 +487,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		"b",
 		"b",
 		".",
-	}, m.Paint(im, 4)))
+	}, PaintWidget(m, im, 4)))
 	assert.Equal(t, nil, checkImage([]string{
 		"b",
 		"b",
@@ -495,7 +495,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		"b",
 		".",
 		".",
-	}, m.Paint(im, 5)))
+	}, PaintWidget(m, im, 5)))
 	assert.Equal(t, nil, checkImage([]string{
 		"b",
 		"b",
@@ -503,7 +503,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		".",
 		".",
 		".",
-	}, m.Paint(im, 6)))
+	}, PaintWidget(m, im, 6)))
 	assert.Equal(t, nil, checkImage([]string{
 		"b",
 		"b",
@@ -511,7 +511,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		".",
 		".",
 		".",
-	}, m.Paint(im, 7)))
+	}, PaintWidget(m, im, 7)))
 	assert.Equal(t, nil, checkImage([]string{
 		"b",
 		".",
@@ -519,7 +519,7 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		".",
 		".",
 		".",
-	}, m.Paint(im, 8)))
+	}, PaintWidget(m, im, 8)))
 	assert.Equal(t, nil, checkImage([]string{
 		".",
 		".",
@@ -527,96 +527,96 @@ func TestMarqueeVerticalScroll(t *testing.T) {
 		".",
 		".",
 		".",
-	}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 11)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 12)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 13)))
-	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, m.Paint(im, 14)))
-	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 15)))
+	}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, PaintWidget(m, im, 11)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, PaintWidget(m, im, 12)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 13)))
+	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, PaintWidget(m, im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, PaintWidget(m, im, 15)))
 	assert.Equal(t, 16, m.FrameCount())
 
 	// Negative OffsetStart
 	m.OffsetStart = -2
-	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", ".", ".", ".", "."}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", ".", ".", ".", "."}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, PaintWidget(m, im, 11)))
 	assert.Equal(t, 12, m.FrameCount())
 
 	// Overly negative OffsetStart is truncated to child width
 	m.OffsetStart = -1000
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, PaintWidget(m, im, 2)))
 	assert.Equal(t, 7, m.FrameCount())
 	m.OffsetStart = -7
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 1)))
 	assert.Equal(t, 7, m.FrameCount())
 	m.OffsetStart = -8
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 1)))
 	assert.Equal(t, 7, m.FrameCount())
 	m.OffsetStart = -6
-	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 2)))
 	assert.Equal(t, 8, m.FrameCount())
 
 	// OffsetEnd affects the final position of the child
 	m.OffsetStart = 0
 	m.OffsetEnd = 2
-	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, m.Paint(im, 3)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 4)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", ".", ".", ".", "."}, m.Paint(im, 5)))
-	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 7)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 11)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, PaintWidget(m, im, 3)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, PaintWidget(m, im, 4)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", ".", ".", ".", "."}, PaintWidget(m, im, 5)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 7)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "r"}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", "r", "g"}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 11)))
 	assert.Equal(t, 12, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 12)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 13)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 1024)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 12)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 13)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 1024)))
 
 	// Negative offset places child outside of marquee
 	m.OffsetEnd = -4
-	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, m.Paint(im, 1)))
-	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 2)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, m.Paint(im, 10)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, m.Paint(im, 11)))
-	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, m.Paint(im, 12)))
-	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 13)))
-	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, m.Paint(im, 14)))
-	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, m.Paint(im, 15)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, m.Paint(im, 16)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 17)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, PaintWidget(m, im, 1)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, PaintWidget(m, im, 2)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", "r", "g", "g"}, PaintWidget(m, im, 10)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", "r", "g", "g", "b"}, PaintWidget(m, im, 11)))
+	assert.Equal(t, nil, checkImage([]string{".", "r", "g", "g", "b", "b"}, PaintWidget(m, im, 12)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, PaintWidget(m, im, 13)))
+	assert.Equal(t, nil, checkImage([]string{"g", "g", "b", "b", "b", "b"}, PaintWidget(m, im, 14)))
+	assert.Equal(t, nil, checkImage([]string{"g", "b", "b", "b", "b", "."}, PaintWidget(m, im, 15)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", "b", ".", "."}, PaintWidget(m, im, 16)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, PaintWidget(m, im, 17)))
 	assert.Equal(t, 18, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 18)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 19)))
-	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, m.Paint(im, 1024)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, PaintWidget(m, im, 18)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, PaintWidget(m, im, 19)))
+	assert.Equal(t, nil, checkImage([]string{"b", "b", "b", ".", ".", "."}, PaintWidget(m, im, 1024)))
 
 	// OffsetEnd >= width means it doesn't scroll back
 	m.OffsetEnd = 6
-	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, m.Paint(im, 0)))
-	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, m.Paint(im, 6)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 7)))
+	assert.Equal(t, nil, checkImage([]string{"r", "g", "g", "b", "b", "b"}, PaintWidget(m, im, 0)))
+	assert.Equal(t, nil, checkImage([]string{"b", ".", ".", ".", ".", "."}, PaintWidget(m, im, 6)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 7)))
 	assert.Equal(t, 8, m.FrameCount())
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 8)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 9)))
-	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, m.Paint(im, 1024)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 8)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 9)))
+	assert.Equal(t, nil, checkImage([]string{".", ".", ".", ".", ".", "."}, PaintWidget(m, im, 1024)))
 }

--- a/render/padding_test.go
+++ b/render/padding_test.go
@@ -21,7 +21,7 @@ func TestPadding(t *testing.T) {
 	}
 
 	// Large bounds
-	im := pad.Paint(image.Rect(0, 0, 20, 20), 0)
+	im := PaintWidget(pad, image.Rect(0, 0, 20, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".......",
 		".......",
@@ -35,7 +35,7 @@ func TestPadding(t *testing.T) {
 	}, im))
 
 	// Small bounds
-	im = pad.Paint(image.Rect(0, 0, 4, 4), 0)
+	im = PaintWidget(pad, image.Rect(0, 0, 4, 4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".......",
 		".......",
@@ -64,7 +64,7 @@ func TestPaddingExpanded(t *testing.T) {
 		Expanded: true,
 	}
 
-	im := pad.Paint(image.Rect(0, 0, 7, 7), 0)
+	im := PaintWidget(pad, image.Rect(0, 0, 7, 7), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".......",
 		".rrr...",
@@ -76,7 +76,7 @@ func TestPaddingExpanded(t *testing.T) {
 	}, im))
 
 	// Child doesn't fit: crop
-	im = pad.Paint(image.Rect(0, 0, 3, 3), 0)
+	im = PaintWidget(pad, image.Rect(0, 0, 3, 3), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...",
 		".r.",
@@ -98,7 +98,7 @@ func TestColorPadding(t *testing.T) {
 	}
 
 	// Large bounds
-	im := pad.Paint(image.Rect(0, 0, 20, 20), 0)
+	im := PaintWidget(pad, image.Rect(0, 0, 20, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"ggggggg",
 		"ggggggg",
@@ -112,7 +112,7 @@ func TestColorPadding(t *testing.T) {
 	}, im))
 
 	// Small bounds
-	im = pad.Paint(image.Rect(0, 0, 4, 4), 0)
+	im = PaintWidget(pad, image.Rect(0, 0, 4, 4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"ggggggg",
 		"ggggggg",
@@ -139,10 +139,10 @@ func TestColorPaddingExpanded(t *testing.T) {
 			Bottom: 1,
 		},
 		Expanded: true,
-		Color: color.RGBA{0, 0xff, 0, 0xff},
+		Color:    color.RGBA{0, 0xff, 0, 0xff},
 	}
 
-	im := pad.Paint(image.Rect(0, 0, 7, 7), 0)
+	im := PaintWidget(pad, image.Rect(0, 0, 7, 7), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"ggggggg",
 		"grrrggg",
@@ -154,7 +154,7 @@ func TestColorPaddingExpanded(t *testing.T) {
 	}, im))
 
 	// Child doesn't fit: crop
-	im = pad.Paint(image.Rect(0, 0, 3, 3), 0)
+	im = PaintWidget(pad, image.Rect(0, 0, 3, 3), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"ggg",
 		"grg",

--- a/render/plot_test.go
+++ b/render/plot_test.go
@@ -189,7 +189,7 @@ func TestPlotFlatLine(t *testing.T) {
 		"1111111111",
 		"..........",
 		"..........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	// Extend view to the left
 	p.XLim[0] = -10
@@ -199,7 +199,7 @@ func TestPlotFlatLine(t *testing.T) {
 		".....11111",
 		"..........",
 		"..........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 }
 
@@ -226,7 +226,7 @@ func TestPlotVerticalLine(t *testing.T) {
 		"1.........",
 		"1.........",
 		"1.........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 }
 
 func TestPlotJaggedLine(t *testing.T) {
@@ -262,7 +262,7 @@ func TestPlotJaggedLine(t *testing.T) {
 		"..1..1.1..",
 		".1...11...",
 		"1....1....",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	// Make it bigger
 	p.Width = 20
@@ -278,7 +278,7 @@ func TestPlotJaggedLine(t *testing.T) {
 		"..1.......1..1......",
 		".1.........11.......",
 		"1..........1........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	// Zoom in on the second valley
 	p.XLim[0] = 5
@@ -297,7 +297,7 @@ func TestPlotJaggedLine(t *testing.T) {
 		"........1........111",
 		".........1...1111...",
 		"..........111.......",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 }
 
@@ -337,7 +337,7 @@ func TestPlotFewPoints(t *testing.T) {
 		"1.1....1.1",
 		"11......11",
 		"1111111111",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 }
 
@@ -376,7 +376,7 @@ func TestPlotInvertedColor(t *testing.T) {
 		"..11..1.11",
 		"....22....",
 		"....22....",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	p.Width = 20
 	p.Height = 10
@@ -391,7 +391,7 @@ func TestPlotInvertedColor(t *testing.T) {
 		".......2...2........",
 		"........2..2........",
 		"........2222........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 }
 
@@ -399,9 +399,9 @@ func TestPlotSurfaceFill(t *testing.T) {
 	ic := ImageChecker{
 		Palette: map[string]color.RGBA{
 			"1": {0x0, 0xff, 0x0, 0xff},
-			",": {0x0, 0xff, 0x0, 0x55},
+			",": {0x0, 0x55, 0x0, 0xff},
 			"2": {0xff, 0, 0, 0xff},
-			":": {0xff, 0, 0, 0x55},
+			":": {0x55, 0, 0, 0xff},
 			".": {0, 0, 0, 0},
 		},
 	}
@@ -433,7 +433,7 @@ func TestPlotSurfaceFill(t *testing.T) {
 		",,,,,,,,,1......1,,,",
 		".........1,,,,,1....",
 		"..........11111.....",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	// Fil with ColorInverted
 	p.ColorInverted = &color.RGBA{0xff, 0, 0, 0xff}
@@ -448,7 +448,7 @@ func TestPlotSurfaceFill(t *testing.T) {
 		",,,,,,,,,1......1,,,",
 		".........2:::::2....",
 		"..........22222.....",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 }
 
 func TestPlotXLim(t *testing.T) {
@@ -496,7 +496,7 @@ func TestPlotXLim(t *testing.T) {
 		".1.....11...........",
 		".1.....11...........",
 		"1......1............",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	// And on the left
 	p.XLim[0] = -4
@@ -512,7 +512,7 @@ func TestPlotXLim(t *testing.T) {
 		"......1...11........",
 		"......1...11........",
 		".....1....1.........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 
 	// And then do the opposite to "zoom in"
 	p.XLim[0] = 3
@@ -528,5 +528,5 @@ func TestPlotXLim(t *testing.T) {
 		"..........1...11....",
 		"...........111......",
 		"...........1........",
-	}, p.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(p, image.Rect(0, 0, 100, 100), 0)))
 }

--- a/render/root.go
+++ b/render/root.go
@@ -56,8 +56,9 @@ func (r Root) Paint(solidBackground bool) []image.Image {
 				dc.Clear()
 			}
 
-			im := r.Child.Paint(image.Rect(0, 0, DefaultFrameWidth, DefaultFrameHeight), i)
-			dc.DrawImage(im, 0, 0)
+			dc.Push()
+			r.Child.Paint(dc, image.Rect(0, 0, DefaultFrameWidth, DefaultFrameHeight), i)
+			dc.Pop()
 			frames[i] = dc.Image()
 			wg.Done()
 		}(i)

--- a/render/row.go
+++ b/render/row.go
@@ -2,6 +2,8 @@ package render
 
 import (
 	"image"
+
+	"github.com/fogleman/gg"
 )
 
 // Row lays out and draws its children horizontally (in a row).
@@ -62,7 +64,7 @@ type Row struct {
 	Expanded   bool
 }
 
-func (r Row) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (r Row) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
 	v := Vector{
 		Vertical:   false,
 		Children:   r.Children,
@@ -70,7 +72,18 @@ func (r Row) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		CrossAlign: r.CrossAlign,
 		Expanded:   r.Expanded,
 	}
-	return v.Paint(bounds, frameIdx)
+	return v.PaintBounds(bounds, frameIdx)
+}
+
+func (r Row) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	v := Vector{
+		Vertical:   false,
+		Children:   r.Children,
+		MainAlign:  r.MainAlign,
+		CrossAlign: r.CrossAlign,
+		Expanded:   r.Expanded,
+	}
+	v.Paint(dc, bounds, frameIdx)
 }
 
 func (r Row) FrameCount() int {

--- a/render/row_test.go
+++ b/render/row_test.go
@@ -25,7 +25,7 @@ func TestRowPaint(t *testing.T) {
 
 	// On large canvas, height gets truncated to max of children,
 	// while width expands to full size
-	im := r.Paint(image.Rect(0, 0, 14+2, 17), 0)
+	im := PaintWidget(r, image.Rect(0, 0, 14+2, 17), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........rrrrrrrr",
 		"........rrrrrrrr",

--- a/render/sequence.go
+++ b/render/sequence.go
@@ -43,16 +43,30 @@ func (s Sequence) FrameCount() int {
 	return fc
 }
 
-func (s Sequence) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (s Sequence) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
 	fc := 0
 
 	for _, c := range s.Children {
 		if frameIdx < fc+c.FrameCount() {
-			return c.Paint(bounds, frameIdx-fc)
+			return c.PaintBounds(bounds, frameIdx-fc)
 		}
 
 		fc += c.FrameCount()
 	}
 
-	return gg.NewContext(0, 0).Image()
+	return image.Rect(0, 0, 0, 0)
+}
+
+func (s Sequence) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	fc := 0
+
+	for _, c := range s.Children {
+		if frameIdx < fc+c.FrameCount() {
+			dc.Push()
+			c.Paint(dc, bounds, frameIdx-fc)
+			dc.Pop()
+		}
+
+		fc += c.FrameCount()
+	}
 }

--- a/render/testutil.go
+++ b/render/testutil.go
@@ -5,6 +5,8 @@ import (
 	"image"
 	"image/color"
 	"strings"
+
+	"github.com/fogleman/gg"
 )
 
 var DefaultPalette = map[string]color.RGBA{
@@ -100,4 +102,11 @@ func checkImage(expected []string, actual image.Image) error {
 func CheckImage(expected []string, actual image.Image) error {
 	ic := ImageChecker{Palette: DefaultPalette}
 	return ic.Check(expected, actual)
+}
+
+func PaintWidget(w Widget, bounds image.Rectangle, frameIdx int) image.Image {
+	pb := w.PaintBounds(bounds, frameIdx)
+	dc := gg.NewContext(pb.Dx(), pb.Dy())
+	w.Paint(dc, bounds, frameIdx)
+	return dc.Image()
 }

--- a/render/text.go
+++ b/render/text.go
@@ -44,10 +44,12 @@ func (t *Text) Size() (int, int) {
 	return t.img.Bounds().Dx(), t.img.Bounds().Dy()
 }
 
-func (t *Text) Paint(
-	bounds image.Rectangle, frameIdx int,
-) image.Image {
-	return t.img
+func (t *Text) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	dc.DrawImage(t.img, 0, 0)
+}
+
+func (t *Text) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
+	return image.Rect(0, 0, t.img.Bounds().Dx(), t.img.Bounds().Dy())
 }
 
 func (t *Text) Init() error {

--- a/render/text_test.go
+++ b/render/text_test.go
@@ -11,7 +11,7 @@ import (
 func TestTextDefault(t *testing.T) {
 	text := &Text{Content: "A"}
 	text.Init()
-	im := text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
 		".ww..",
@@ -28,7 +28,7 @@ func TestTextDefault(t *testing.T) {
 
 	text = &Text{Content: "j!ÑÖ"}
 	text.Init()
-	im = text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...." + ".." + ".w.w." + "w..w.",
 		"..w." + "w." + "w.w.." + ".....",
@@ -51,7 +51,7 @@ func TestTextParameters(t *testing.T) {
 	}
 	text.Init()
 
-	im := text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......" + "......",
 		"......" + "......",
@@ -80,7 +80,7 @@ func TestTextParameters(t *testing.T) {
 		Height:  10,
 	}
 	text.Init()
-	im = text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......" + "......",
 		".g..g." + "ggggg.",
@@ -110,7 +110,7 @@ func TestTextFonts(t *testing.T) {
 	}
 	text.Init()
 
-	im := text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......" + "......" + "......" + "......",
 		"......" + "......" + ".w.w.." + "......",
@@ -135,7 +135,7 @@ func TestTextFonts(t *testing.T) {
 		Font:    "Dina_r400-6",
 	}
 	text.Init()
-	im = text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......" + "......" + ".w.w.." + "......",
 		"......" + "......" + "......" + "......",
@@ -157,7 +157,7 @@ func TestTextFonts(t *testing.T) {
 		Font:    "5x8",
 	}
 	text.Init()
-	im = text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "....." + "w..w." + ".....",
 		".ww.." + "....." + "....." + "..w..",
@@ -177,7 +177,7 @@ func TestTextFonts(t *testing.T) {
 		Font:    "tb-8",
 	}
 	text.Init()
-	im = text.Paint(image.Rect(0, 0, 0, 0), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "....." + "w..w." + "..",
 		".ww.." + "....." + "....." + "w.",

--- a/render/tracer.go
+++ b/render/tracer.go
@@ -17,21 +17,23 @@ func (t Tracer) FrameCount() int {
 	return t.Path.Length()
 }
 
-func (t Tracer) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (t Tracer) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
 	width, height := t.Path.Size()
-	dc := gg.NewContext(width, height)
+	return image.Rect(0, 0, width, height)
+}
 
+func (t Tracer) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 	x, y := t.Path.Point(frameIdx)
 
 	dc.SetColor(color.RGBA{0xff, 0xff, 0xff, 0xff})
-	dc.SetPixel(x, y)
+	tx, ty := dc.TransformPoint(float64(x), float64(y))
+	dc.SetPixel(int(tx), int(ty))
 
 	for i := 0; i < t.TraceLength; i++ {
 		col := uint8(0xdd - i*(0xff/t.TraceLength))
 		dc.SetColor(color.RGBA{col, col, col, 0xff})
 		x, y := t.Path.Point(frameIdx - (i + 1))
-		dc.SetPixel(x, y)
+		tx, ty := dc.TransformPoint(float64(x), float64(y))
+		dc.SetPixel(int(tx), int(ty))
 	}
-
-	return dc.Image()
 }

--- a/render/tracer_test.go
+++ b/render/tracer_test.go
@@ -31,7 +31,7 @@ func TestTracerCircularPath(t *testing.T) {
 		"........",
 		"........",
 		"........",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 0)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 0)))
 
 	assert.Equal(t, nil, ic.Check([]string{
 		"........",
@@ -42,7 +42,7 @@ func TestTracerCircularPath(t *testing.T) {
 		".......1",
 		"........",
 		"........",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 1)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 1)))
 
 	assert.Equal(t, nil, ic.Check([]string{
 		"........",
@@ -53,7 +53,7 @@ func TestTracerCircularPath(t *testing.T) {
 		"........",
 		".......1",
 		"........",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 2)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 2)))
 
 	assert.Equal(t, nil, ic.Check([]string{
 		"........",
@@ -64,7 +64,7 @@ func TestTracerCircularPath(t *testing.T) {
 		"........",
 		"........",
 		"......1.",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 3)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 3)))
 
 	// Spot check third quadrant
 	assert.Equal(t, nil, ic.Check([]string{
@@ -76,7 +76,7 @@ func TestTracerCircularPath(t *testing.T) {
 		"........",
 		"........",
 		"........",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 14)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 14)))
 
 	// Last pixel and verify it loops
 	assert.Equal(t, nil, ic.Check([]string{
@@ -88,7 +88,7 @@ func TestTracerCircularPath(t *testing.T) {
 		"........",
 		"........",
 		"........",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 23)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 23)))
 
 	assert.Equal(t, nil, ic.Check([]string{
 		"........",
@@ -99,7 +99,7 @@ func TestTracerCircularPath(t *testing.T) {
 		".......1",
 		"........",
 		"........",
-	}, tr.Paint(image.Rect(0, 0, 100, 100), 25)))
+	}, PaintWidget(tr, image.Rect(0, 0, 100, 100), 25)))
 
 	// All in all, we should have 24 frames
 	assert.Equal(t, 24, tr.FrameCount())

--- a/render/vector_test.go
+++ b/render/vector_test.go
@@ -25,7 +25,7 @@ func TestVectorMainAlignStart(t *testing.T) {
 
 	// On large canvas, height gets truncated to max of children,
 	// while width expands to full size
-	im := v.Paint(image.Rect(0, 0, 25, 20), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 25, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrrggggggbb.......",
 		"rrrrrrrrrrggggggbb.......",
@@ -42,7 +42,7 @@ func TestVectorMainAlignStart(t *testing.T) {
 	}, im))
 
 	// Reduce height. Overflowing children are partially drawn.
-	im = v.Paint(image.Rect(0, 0, 25, 10), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 25, 10), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrrggggggbb.......",
 		"rrrrrrrrrrggggggbb.......",
@@ -57,7 +57,7 @@ func TestVectorMainAlignStart(t *testing.T) {
 	}, im))
 
 	// Reduce width further.
-	im = v.Paint(image.Rect(0, 0, 17, 10), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 17, 10), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrrggggggb",
 		"rrrrrrrrrrggggggb",
@@ -73,7 +73,7 @@ func TestVectorMainAlignStart(t *testing.T) {
 
 	// Reduce so a child is completely cut out, and it's no longer
 	// included in height.
-	im = v.Paint(image.Rect(0, 0, 16, 10), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 16, 10), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrrgggggg",
 		"rrrrrrrrrrgggggg",
@@ -86,7 +86,7 @@ func TestVectorMainAlignStart(t *testing.T) {
 	}, im))
 
 	// Perfect fit is a perfect fit.
-	im = v.Paint(image.Rect(0, 0, 18, 12), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 18, 12), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrrggggggbb",
 		"rrrrrrrrrrggggggbb",
@@ -104,7 +104,7 @@ func TestVectorMainAlignStart(t *testing.T) {
 
 	// Flip it
 	v.Vertical = true
-	im = v.Paint(image.Rect(0, 0, 10, 25), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10, 25), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrrrrrrr",
 		"rrrrrrrrrr",
@@ -151,7 +151,7 @@ func TestVectorMainAlignStartVertical(t *testing.T) {
 	}
 
 	// Width shrinks to fit
-	im := v.Paint(image.Rect(0, 0, 100, 11), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 100, 11), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr........",
 		"rrrr........",
@@ -167,7 +167,7 @@ func TestVectorMainAlignStartVertical(t *testing.T) {
 	}, im))
 
 	// Height does not shrink
-	im = v.Paint(image.Rect(0, 0, 100, 13), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 100, 13), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr........",
 		"rrrr........",
@@ -185,7 +185,7 @@ func TestVectorMainAlignStartVertical(t *testing.T) {
 	}, im))
 
 	// Children are partially drawn
-	im = v.Paint(image.Rect(0, 0, 10, 13), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10, 13), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr......",
 		"rrrr......",
@@ -203,7 +203,7 @@ func TestVectorMainAlignStartVertical(t *testing.T) {
 	}, im))
 
 	// Along both axes
-	im = v.Paint(image.Rect(0, 0, 10, 10), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10, 10), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr......",
 		"rrrr......",
@@ -219,7 +219,7 @@ func TestVectorMainAlignStartVertical(t *testing.T) {
 
 	// And if a child is completely out of sight, it no longer
 	// affects width
-	im = v.Paint(image.Rect(0, 0, 10, 9), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10, 9), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr....",
 		"rrrr....",
@@ -251,7 +251,7 @@ func TestVectorMainAlignEnd(t *testing.T) {
 
 	// With MainAlignEnd, children are placed at the end along the
 	// main axis
-	im := v.Paint(image.Rect(0, 0, 100, 13), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 100, 13), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",
@@ -270,7 +270,7 @@ func TestVectorMainAlignEnd(t *testing.T) {
 
 	// Flip it!
 	v.Vertical = false
-	im = v.Paint(image.Rect(0, 0, 19, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 19, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrrrggggggggbbbbb",
 		"..rrrrggggggggbbbbb",
@@ -281,7 +281,7 @@ func TestVectorMainAlignEnd(t *testing.T) {
 	}, im))
 
 	// Reducing width/height
-	im = v.Paint(image.Rect(0, 0, 16, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 16, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrggggggggbbbb",
 		"rrrrggggggggbbbb",
@@ -290,7 +290,7 @@ func TestVectorMainAlignEnd(t *testing.T) {
 		"rrrr............",
 		"rrrr............",
 	}, im))
-	im = v.Paint(image.Rect(0, 0, 16, 5), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 16, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrggggggggbbbb",
 		"rrrrggggggggbbbb",
@@ -298,7 +298,7 @@ func TestVectorMainAlignEnd(t *testing.T) {
 		"rrrr............",
 		"rrrr............",
 	}, im))
-	im = v.Paint(image.Rect(0, 0, 16, 5), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 16, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrggggggggbbbb",
 		"rrrrggggggggbbbb",
@@ -325,7 +325,7 @@ func TestVectorMainAlignSpaceEvenly(t *testing.T) {
 	}
 
 	// Canvas leaves 2 pixels spacing before and after each child
-	im := v.Paint(image.Rect(0, 0, 17+2*4, 100), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 17+2*4, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrrr..gggggggg..bbbbb..",
 		"..rrrr..gggggggg..bbbbb..",
@@ -338,7 +338,7 @@ func TestVectorMainAlignSpaceEvenly(t *testing.T) {
 	// Adding 2 pixels width means canvas doesn't divide
 	// evenly. The residual should be distributed start to end,
 	// one pixel at a time.
-	im = v.Paint(image.Rect(0, 0, 17+2*4+2, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 17+2*4+2, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...rrrr...gggggggg..bbbbb..",
 		"...rrrr...gggggggg..bbbbb..",
@@ -350,7 +350,7 @@ func TestVectorMainAlignSpaceEvenly(t *testing.T) {
 
 	// If not expanded, this just shrink wraps to smallest size
 	v.Expanded = false
-	im = v.Paint(image.Rect(0, 0, 17+2*4+2, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 17+2*4+2, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrrggggggggbbbbb",
 		"rrrrggggggggbbbbb",
@@ -362,7 +362,7 @@ func TestVectorMainAlignSpaceEvenly(t *testing.T) {
 
 	// Flip it
 	v.Vertical = true
-	im = v.Paint(image.Rect(0, 0, 100, 11+2*4+2), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 100, 11+2*4+2), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr....",
 		"rrrr....",
@@ -379,7 +379,7 @@ func TestVectorMainAlignSpaceEvenly(t *testing.T) {
 
 	// And unexpand it
 	v.Expanded = true
-	im = v.Paint(image.Rect(0, 0, 100, 11+2*4+2), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 100, 11+2*4+2), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",
@@ -424,7 +424,7 @@ func TestVectorCrossAlignCenter(t *testing.T) {
 
 	// Everything centered along the cross axis. Space isn't
 	// evenly divisible for the green box.
-	im := v.Paint(image.Rect(0, 0, 17+2*4, 100), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 17+2*4, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrrr...................",
 		"..rrrr..gggggggg.........",
@@ -436,7 +436,7 @@ func TestVectorCrossAlignCenter(t *testing.T) {
 
 	// Flip it!
 	v.Vertical = true
-	im = v.Paint(image.Rect(0, 0, 10000, 11+2*4), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10000, 11+2*4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",
@@ -461,7 +461,7 @@ func TestVectorCrossAlignCenter(t *testing.T) {
 
 	// Unexpand it
 	v.Expanded = false
-	im = v.Paint(image.Rect(0, 0, 10000, 11+2*4), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10000, 11+2*4), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrrr..",
 		"..rrrr..",
@@ -479,7 +479,7 @@ func TestVectorCrossAlignCenter(t *testing.T) {
 	// Works with other main axis alignment
 	v.Expanded = true
 	v.MainAlign = "start"
-	im = v.Paint(image.Rect(0, 0, 10000, 11+2), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10000, 11+2), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrrr..",
 		"..rrrr..",
@@ -496,7 +496,7 @@ func TestVectorCrossAlignCenter(t *testing.T) {
 		"........",
 	}, im))
 	v.MainAlign = "end"
-	im = v.Paint(image.Rect(0, 0, 10000, 11+2), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10000, 11+2), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",
@@ -532,7 +532,7 @@ func TestVectorCrossAlignEnd(t *testing.T) {
 		},
 	}
 
-	im := v.Paint(image.Rect(0, 0, 17+2*4+1, 100), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 17+2*4+1, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...rrrr...................",
 		"...rrrr...................",
@@ -543,7 +543,7 @@ func TestVectorCrossAlignEnd(t *testing.T) {
 	}, im))
 
 	v.Vertical = true
-	im = v.Paint(image.Rect(0, 0, 10000, 11+2*4+1), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10000, 11+2*4+1), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",
@@ -586,7 +586,7 @@ func TestVectorCrossAlignStart(t *testing.T) {
 		},
 	}
 
-	im := v.Paint(image.Rect(0, 0, 17+2*4+1, 100), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 17+2*4+1, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".........rrrrggggggggbbbbb",
 		".........rrrrggggggggbbbbb",
@@ -597,7 +597,7 @@ func TestVectorCrossAlignStart(t *testing.T) {
 	}, im))
 
 	v.Vertical = true
-	im = v.Paint(image.Rect(0, 0, 10000, 11+2*4+1), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10000, 11+2*4+1), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"........",
 		"........",
@@ -622,7 +622,7 @@ func TestVectorCrossAlignStart(t *testing.T) {
 	}, im))
 
 	v.Expanded = false
-	im = v.Paint(image.Rect(0, 0, 7, 11+2*4+1), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 7, 11+2*4+1), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrr...",
 		"rrrr...",
@@ -661,7 +661,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 	// bit unintuitive, but I couldn't come up with anything
 	// better. These tests illustrate (and verify) the behavior.
 
-	im := v.Paint(image.Rect(0, 0, 9, 20), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 9, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrgggggb",
 		"rrrgggggb",
@@ -669,7 +669,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		"rrr......",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 10, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rrrgggggb",
 		".rrrgggggb",
@@ -677,7 +677,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		".rrr......",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 11, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 11, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rrr.gggggb",
 		".rrr.gggggb",
@@ -692,7 +692,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 	// blue. However, since that comes in 1 pixel short, the final
 	// column of pixels is not painted, which comes out as
 	// padding. So it makes sense, but it also doesn't.
-	im = v.Paint(image.Rect(0, 0, 12, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 12, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr.ggggg.b.",
 		"rrr.ggggg.b.",
@@ -700,7 +700,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		"rrr.........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 13, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 13, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rrr.ggggg.b.",
 		".rrr.ggggg.b.",
@@ -708,7 +708,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		".rrr.........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 14, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 14, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rrr..ggggg.b.",
 		".rrr..ggggg.b.",
@@ -716,7 +716,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		".rrr..........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 15, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 15, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".rrr..ggggg..b.",
 		".rrr..ggggg..b.",
@@ -724,7 +724,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		".rrr...........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 16, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 16, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrr..ggggg..b.",
 		"..rrr..ggggg..b.",
@@ -732,7 +732,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 		"..rrr...........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 20, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 20, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrr....ggggg...b..",
 		"..rrr....ggggg...b..",
@@ -743,7 +743,7 @@ func TestVectorMainAlignSpaceAround(t *testing.T) {
 	// And flip it up a bit
 	v.Vertical = true
 	v.CrossAlign = "center"
-	im = v.Paint(image.Rect(0, 0, 20, 20), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 20, 20), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
 		".....",
@@ -784,7 +784,7 @@ func TestVectorMainAlignCenter(t *testing.T) {
 	// MainAlignCenter places children adjacent without spacing,
 	// centered along the main axis.
 
-	im := v.Paint(image.Rect(0, 0, 100, 12), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 100, 12), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
 		"rrr..",
@@ -800,7 +800,7 @@ func TestVectorMainAlignCenter(t *testing.T) {
 		".....",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 100, 11), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 100, 11), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
 		"rrr..",
@@ -817,7 +817,7 @@ func TestVectorMainAlignCenter(t *testing.T) {
 
 	v.Vertical = false
 	v.CrossAlign = "center"
-	im = v.Paint(image.Rect(0, 0, 13, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 13, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"..rrr.....b..",
 		"..rrrgggggb..",
@@ -842,7 +842,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 	// children, but not before the first child or after the last
 	// child.
 
-	im := v.Paint(image.Rect(0, 0, 9, 100), 0)
+	im := PaintWidget(v, image.Rect(0, 0, 9, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrrgggggb",
 		"rrrgggggb",
@@ -850,7 +850,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		"rrr......",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 10, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 10, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr.gggggb",
 		"rrr.gggggb",
@@ -858,7 +858,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		"rrr.......",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 11, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 11, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr.ggggg.b",
 		"rrr.ggggg.b",
@@ -866,7 +866,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		"rrr........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 12, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 12, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr..ggggg.b",
 		"rrr..ggggg.b",
@@ -874,7 +874,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		"rrr.........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 13, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 13, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr..ggggg..b",
 		"rrr..ggggg..b",
@@ -882,7 +882,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		"rrr..........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 14, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 14, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr...ggggg..b",
 		"rrr...ggggg..b",
@@ -890,7 +890,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		"rrr...........",
 	}, im))
 
-	im = v.Paint(image.Rect(0, 0, 15, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 15, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr...ggggg...b",
 		"rrr...ggggg...b",
@@ -911,7 +911,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		},
 	}
 
-	im = v.Paint(image.Rect(0, 0, 14, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 14, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr...........",
 		"rrr......ggggg",
@@ -929,7 +929,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		},
 	}
 
-	im = v.Paint(image.Rect(0, 0, 14, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 14, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr...........",
 		"rrr...........",
@@ -953,7 +953,7 @@ func TestVectorMainAlignSpaceBetween(t *testing.T) {
 		},
 	}
 
-	im = v.Paint(image.Rect(0, 0, 50, 100), 0)
+	im = PaintWidget(v, image.Rect(0, 0, 50, 100), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"rrr...................b.......................bbbb",
 		"rrr...................b..............rrr......bbbb",

--- a/render/widget.go
+++ b/render/widget.go
@@ -2,11 +2,15 @@ package render
 
 import (
 	"image"
+
+	"github.com/fogleman/gg"
 )
 
 // A Widget is a self-contained object that can render itself as an image.
 type Widget interface {
-	Paint(bounds image.Rectangle, frameIdx int) image.Image
+	// PaintBounds Returns the bounds of the area that will actually be drawn to when Paint() is called
+	PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle
+	Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int)
 	FrameCount() int
 }
 

--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -36,20 +36,13 @@ type WrappedText struct {
 	Width       int
 	LineSpacing int
 	Color       color.Color
-	Align   	string
+	Align       string
 }
 
-func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
+func (tw WrappedText) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle {
 	face := Font[DefaultFontFace]
 	if tw.Font != "" {
 		face = Font[tw.Font]
-	}
-	// Text alignment
-	align := gg.AlignLeft
-	if tw.Align == "center" {
-		align = gg.AlignCenter
-	} else if tw.Align == "right" {
-		align = gg.AlignRight
 	}
 	// The bounds provided by user or parent widget
 	width := tw.Width
@@ -61,7 +54,7 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		height = bounds.Dy()
 	}
 	linespace := float64(tw.LineSpacing)
-	if linespace <=0{ 
+	if linespace <= 0 {
 		linespace = 0
 	}
 	// Compute size of multi line string
@@ -77,7 +70,7 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		if lw > w {
 			w = lw
 		}
-		h += lh+linespace
+		h += lh + linespace
 	}
 
 	// Size of drawing context
@@ -97,11 +90,27 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		height = bounds.Dy()
 	}
 
+	return image.Rect(0, 0, width, height)
+}
+
+func (tw WrappedText) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
+	face := Font[DefaultFontFace]
+	if tw.Font != "" {
+		face = Font[tw.Font]
+	}
+	// Text alignment
+	align := gg.AlignLeft
+	if tw.Align == "center" {
+		align = gg.AlignCenter
+	} else if tw.Align == "right" {
+		align = gg.AlignRight
+	}
+
+	width := tw.PaintBounds(bounds, frameIdx).Dx()
+
 	metrics := face.Metrics()
 	descent := metrics.Descent.Floor()
 
-	// And draw
-	dc = gg.NewContext(width, height)
 	dc.SetFontFace(face)
 	if tw.Color != nil {
 		dc.SetColor(tw.Color)
@@ -119,8 +128,6 @@ func (tw WrappedText) Paint(bounds image.Rectangle, frameIdx int) image.Image {
 		(float64(tw.LineSpacing)+dc.FontHeight())/dc.FontHeight(),
 		align,
 	)
-
-	return dc.Image()
 }
 
 func (tw WrappedText) FrameCount() int {

--- a/render/wrappedtext_test.go
+++ b/render/wrappedtext_test.go
@@ -11,7 +11,7 @@ func TestWrappedTextWithBounds(t *testing.T) {
 	text := WrappedText{Content: "AB CD."}
 
 	// Sufficient space to fit on single line
-	im := text.Paint(image.Rect(0, 0, 25, 8), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 25, 8), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "........" + "....." + ".......",
 		".ww.." + "www....." + ".ww.." + "www....",
@@ -24,7 +24,7 @@ func TestWrappedTextWithBounds(t *testing.T) {
 	}, im))
 
 	// Reduce avaialable width and it wraps
-	im = text.Paint(image.Rect(0, 0, 21, 16), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
 		".ww.." + "www....",
@@ -45,7 +45,7 @@ func TestWrappedTextWithBounds(t *testing.T) {
 	}, im))
 
 	// Overflow is cut off
-	im = text.Paint(image.Rect(0, 0, 7, 12), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 7, 12), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "..",
 		".ww.." + "ww",
@@ -65,7 +65,7 @@ func TestWrappedTextWithBounds(t *testing.T) {
 func TestWrappedTextWithSize(t *testing.T) {
 	// Weight and Height parameters override the bounds
 	text := WrappedText{Content: "AB CD.", Width: 7, Height: 12}
-	im := text.Paint(image.Rect(0, 0, 40, 40), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 40, 40), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "..",
 		".ww.." + "ww",
@@ -83,7 +83,7 @@ func TestWrappedTextWithSize(t *testing.T) {
 
 	// Height can be overridden separately
 	text = WrappedText{Content: "AB CD.", Height: 12}
-	im = text.Paint(image.Rect(0, 0, 9, 40), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 9, 40), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "....",
 		".ww.." + "www.",
@@ -101,7 +101,7 @@ func TestWrappedTextWithSize(t *testing.T) {
 
 	// Ditto for Width
 	text = WrappedText{Content: "AB CD.", Width: 3}
-	im = text.Paint(image.Rect(0, 0, 9, 5), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 9, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...",
 		".ww",
@@ -115,7 +115,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 
 	// Single pixel line space
 	text := WrappedText{Content: "AB CD.", LineSpacing: 1}
-	im := text.Paint(image.Rect(0, 0, 21, 16), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
 		".ww.." + "www....",
@@ -137,7 +137,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 
 	// Add another one
 	text = WrappedText{Content: "AB CD.", LineSpacing: 2}
-	im = text.Paint(image.Rect(0, 0, 21, 16), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
 		".ww.." + "www....",
@@ -161,7 +161,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 func TestWrappedTextAlignment(t *testing.T) {
 	// Default to left align.
 	text := WrappedText{Content: "AB CD."}
-	im := text.Paint(image.Rect(0, 0, 21, 16), 0)
+	im := PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......." + ".....",
 		".ww..ww" + "w....",
@@ -183,7 +183,7 @@ func TestWrappedTextAlignment(t *testing.T) {
 
 	// Right alignment.
 	text = WrappedText{Content: "AB CD.", Align: "right"}
-	im = text.Paint(image.Rect(0, 0, 21, 16), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......." + ".....",
 		"...ww.." + "www..",
@@ -205,7 +205,7 @@ func TestWrappedTextAlignment(t *testing.T) {
 
 	// Center alignment.
 	text = WrappedText{Content: "AB CD.", Align: "center"}
-	im = text.Paint(image.Rect(0, 0, 21, 16), 0)
+	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......." + ".....",
 		"..ww..w" + "ww...",

--- a/runtime/render_test.go
+++ b/runtime/render_test.go
@@ -171,7 +171,7 @@ def main():
 	assert.IsType(t, &render.Box{}, box.Child)
 	assert.Equal(t, box.Child.(*render.Box).Height, 2)
 
-	assert.Equal(t, image.Rect(0, 0, 2, 1), widget.Paint(image.Rect(0, 0, 64, 32), 0).Bounds())
+	assert.Equal(t, image.Rect(0, 0, 2, 1), render.PaintWidget(widget, image.Rect(0, 0, 64, 32), 0).Bounds())
 }
 
 func TestText(t *testing.T) {
@@ -208,7 +208,7 @@ def main():
 	r, g, b, a := text.Color.RGBA()
 	assert.Equal(t, []uint32{eR, eG, eB, eA}, []uint32{r, g, b, a})
 
-	rendered := widget.Paint(image.Rect(0, 0, 64, 32), 0)
+	rendered := render.PaintWidget(widget, image.Rect(0, 0, 64, 32), 0)
 	assert.Greater(t, rendered.Bounds().Dx(), 0)
 	assert.Equal(t, text.Height, rendered.Bounds().Dy())
 }
@@ -216,7 +216,7 @@ def main():
 func TestImage(t *testing.T) {
 	// create a new PNG with a single blue pixel
 	bounds := image.Rect(0, 0, 64, 32)
-	blue := color.NRGBA{0, 0, 255, 255}
+	blue := color.RGBA{0, 0, 255, 255}
 
 	im := image.NewRGBA(bounds)
 	im.Set(12, 12, blue)
@@ -242,7 +242,7 @@ def main():
 	starlarkP := app.Globals["img"]
 	require.IsType(t, &render_runtime.Image{}, starlarkP)
 
-	actualIm := starlarkP.(*render_runtime.Image).AsRenderWidget().Paint(image.Rect(0, 0, 64, 32), 0)
+	actualIm := render.PaintWidget(starlarkP.(*render_runtime.Image).AsRenderWidget(), image.Rect(0, 0, 64, 32), 0)
 	assert.Equal(t, bounds, actualIm.Bounds())
 	assert.Equal(t, blue, actualIm.At(12, 12))
 }


### PR DESCRIPTION
This implements improvement 2 discussed in issue https://github.com/tidbyt/pixlet/issues/350.

The core changes are:

- Create a single graphics context per frame and pass it to all widgets that are to be drawn
- Add another function to the widget interface for calculating paint bounds without actually drawing anything

# Testing
The changes introduced here have the potential to alter the appearance of existing applets. Of course I ensured that all existing tests succeed, but it doesn't seem like they have 100% coverage.

In addition to the existing tests, I wrote a small utility program (not in the commit) that runs pixlet with and without this change on all applets in the community repo. I then compared file sizes to identify applets that did not render identical, and proceeded to investigate on those. Besides widgets involving randomness, I found a few differences in rounding and clipping that I was mostly able to fix.

The only remaining _visual_ difference affects a corner case of the marquee widget: If the scrolled content is longer than the arbitrarily chosen `10*Marquee.height/width`, the text used to be clipped at the end of that boundary (actually quite ugly), while the new implementation does not do that (it just stops scrolling beyond that boundary). This change seems to only affect the mlb_leaders applet.

For completeness, the following applets rendered visually identical, but differed in webp file size by a few bytes: analog_clock, mbta_new_trains, mbta, mlb_scores, mls_scores, nfl_scores, nhl_scores, powerball, tcat_bus_arrivals, verge_taglines, moretransit, ogs_games_viewer, weather_map, ct_lightrail, sound_transit. The reason is likely slightly changed anti-aliasing behaviour (also see the test in `render/animation/transformation_test.go`)

It is also worth noting that I changed the surface drawing color of the plot widget. The logic used there might draw pixels multiple times, which leads to visual artefacts when using alpha blending. To mitigate the issue, I changed the code to derive the fill color by dampening the line color instead of making it translucent. AFAICT, this doesn't visibly affect any existing apps (they were all previously rendering the plot widget on top of a black background anyway).

Lastly, I also adapted the starfield widget, but the changes remain untested. I couldn't find any documentation or reference to the widget anywhere.

# Performance
I also used my utility tool described above for measuring the speedup across all community apps.

Depending on the run, I have consistently seen an average speedup between 2-3x (never below 2.2x, never above 2.9x) on the MacBook Pro I used for development. I did not execute the extensive test on a Raspberry Pi Zero, but see a very similar speedup on the subset of applets I tested there as well.

It is worth noting that more rendering speedup is likely possible, but not while retaining the clipping behaviour of the old implementation.