### PR TITLE
Fix plot fill for extremely one-sided plots

### DIFF
--- a/render/plot.go
+++ b/render/plot.go
@@ -224,13 +224,13 @@ func (p Plot) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 		}
 		if y > p.invThreshold {
 			dc.SetColor(fillColInv)
-			for ; y != p.invThreshold; y-- {
+			for ; y != p.invThreshold && y >= 0; y-- {
 				tx, ty := dc.TransformPoint(float64(x), float64(y))
 				dc.SetPixel(int(tx), int(ty))
 			}
 		} else {
 			dc.SetColor(fillCol)
-			for ; y <= p.invThreshold; y++ {
+			for ; y <= p.invThreshold && y <= p.Height; y++ {
 				tx, ty := dc.TransformPoint(float64(x), float64(y))
 				dc.SetPixel(int(tx), int(ty))
 			}


### PR DESCRIPTION
If all plot points are far negative, the plot widget draws its surface up to invThreshold even if that value is outside of the plot bounds. The problem started to become apparent with the change to the shared drawing context.

Same likely also applies to plots that are far positive (though only if the plot is drawn on the top half of the screen). This PR fixes both variants of the issue.

Before:
![before](https://user-images.githubusercontent.com/3320822/183715199-6d78f285-a840-40c7-a7d2-5088117fb14f.gif)

After:
![after](https://user-images.githubusercontent.com/3320822/183715286-50ab374a-0420-41b4-83fb-267b42588e0a.gif)

