### PR TITLE
random: add seed() for deterministic PRNG

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -182,10 +182,11 @@ See [examples/sunrise.star](../examples/sunrise.star) for an example.
 
 ## Pixlet module: Random
 
-The `random` module provides a pseudorandom number generator for pixlet.
+The `random` module provides a pseudorandom number generator for pixlet. The generator is automatically seeded to a new random value on each execution, but a deterministic seed can also be set.
 
 | Function | Description |
 | --- | --- |
+| `seed(s)` | Seeds the generator.|
 | `number(min, max)` | Returns a random number between the min and max. The min has to be 0 or greater. The min has to be less then the max. |
 
 Example:

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -77,6 +77,8 @@ func (a *Applet) thread(initializers ...ThreadInitializer) *starlark.Thread {
 		a.decrypter.attachToThread(t)
 	}
 
+	random.AttachRandToThread(t)
+
 	for _, init := range initializers {
 		t = init(t)
 	}

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -77,7 +77,7 @@ func (a *Applet) thread(initializers ...ThreadInitializer) *starlark.Thread {
 		a.decrypter.attachToThread(t)
 	}
 
-	random.AttachRandToThread(t)
+	random.AttachToThread(t)
 
 	for _, init := range initializers {
 		t = init(t)

--- a/runtime/modules/random/random.go
+++ b/runtime/modules/random/random.go
@@ -11,13 +11,23 @@ import (
 )
 
 const (
-	ModuleName = "random"
+	ModuleName    = "random"
+	threadRandKey = "tidbyt.dev/pixlet/runtime/random"
 )
 
 var (
 	once   sync.Once
 	module starlark.StringDict
 )
+
+func AttachRandToThread(t *starlark.Thread) {
+	t.SetLocal(
+		threadRandKey,
+		rand.New(
+			rand.NewSource(rand.Int63()),
+		),
+	)
+}
 
 func LoadModule() (starlark.StringDict, error) {
 	once.Do(func() {
@@ -27,12 +37,39 @@ func LoadModule() (starlark.StringDict, error) {
 				Name: ModuleName,
 				Members: starlark.StringDict{
 					"number": starlark.NewBuiltin("number", randomNumber),
+					"seed":   starlark.NewBuiltin("seed", randomSeed),
 				},
 			},
 		}
 	})
 
 	return module, nil
+}
+
+func randomSeed(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var starSeed starlark.Int
+
+	if err := starlark.UnpackArgs(
+		"seed",
+		args, kwargs,
+		"seed", &starSeed,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for seed: %w", err)
+	}
+
+	seed, ok := starSeed.Int64()
+	if !ok {
+		return nil, fmt.Errorf("casting seed to int64")
+	}
+
+	rng, ok := thread.Local(threadRandKey).(*rand.Rand)
+	if !ok || rng == nil {
+		return nil, fmt.Errorf("RNG not set (very bad)")
+	}
+
+	rng.Seed(seed)
+
+	return starlark.None, nil
 }
 
 func randomNumber(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -70,7 +107,10 @@ func randomNumber(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 		return nil, fmt.Errorf("max is less then min")
 	}
 
-	number := rand.Int63n(max-min+1) + min
+	rng, ok := thread.Local(threadRandKey).(*rand.Rand)
+	if !ok || rng == nil {
+		return nil, fmt.Errorf("RNG not set (very bad!)")
+	}
 
-	return starlark.MakeInt64(number), nil
+	return starlark.MakeInt64(rng.Int63n(max-min+1) + min), nil
 }

--- a/runtime/modules/random/random.go
+++ b/runtime/modules/random/random.go
@@ -20,7 +20,7 @@ var (
 	module starlark.StringDict
 )
 
-func AttachRandToThread(t *starlark.Thread) {
+func AttachToThread(t *starlark.Thread) {
 	t.SetLocal(
 		threadRandKey,
 		rand.New(

--- a/runtime/modules/random/random_test.go
+++ b/runtime/modules/random/random_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"tidbyt.dev/pixlet/runtime"
 )
 
@@ -11,17 +12,35 @@ var randomSrc = `
 load("random.star", "random")
 
 min = 100
-max = 200
+max = 120
 
-def run_test():
-	for x in range(0, 100):
+def test_number():
+	for x in range(0, 300):
 		num = random.number(min, max)
 		if num < min:
 			fail("random number less then min")
 		if num > max:
 			fail("random number greater then max")
 
-run_test()
+def test_seed():
+    random.seed(4711)
+    sequence = [random.number(0, 1 << 20) for _ in range(500)]
+
+    random.seed(4711) # same seed
+    for i in range(len(sequence)):
+        if sequence[i] != random.number(0, 1 << 20):
+            fail("sequence mismatch despite identical seed")
+
+    random.seed(4712) # diferent seed
+    different = 0
+    for i in range(len(sequence)):
+        if sequence[i] != random.number(0, 1 << 20):
+            different += 1
+    if not different:
+        fail("sequences identical despite different seeds")
+
+test_number()
+test_seed()
 
 def main():
 	return []
@@ -30,9 +49,9 @@ def main():
 func TestRandom(t *testing.T) {
 	app := &runtime.Applet{}
 	err := app.Load("random_test.star", []byte(randomSrc), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	screens, err := app.Run(map[string]string{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, screens)
 }

--- a/runtime/modules/random/random_test.go
+++ b/runtime/modules/random/random_test.go
@@ -31,7 +31,7 @@ def test_seed():
         if sequence[i] != random.number(0, 1 << 20):
             fail("sequence mismatch despite identical seed")
 
-    random.seed(4712) # diferent seed
+    random.seed(4712) # different seed
     different = 0
     for i in range(len(sequence)):
         if sequence[i] != random.number(0, 1 << 20):


### PR DESCRIPTION
This makes the RNG thread-local, and by default reseeded on each applet execution.
User has the option of setting their own seed, which lasts for 1 execution of the applet.