### PR TITLE
Add `pixlet devices` command

### DIFF
--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	TidbytAPIListDevices = "https://api.tidbyt.com/v0/devices"
+)
+
+var DevicesCmd = &cobra.Command{
+	Use:   "devices",
+	Short: "List devices in your Tidbyt account",
+	Run:   devices,
+}
+
+func devices(cmd *cobra.Command, args []string) {
+	apiToken = oauthTokenFromConfig(cmd.Context())
+	if apiToken == "" {
+		fmt.Println("login with `pixlet login`")
+		os.Exit(1)
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", TidbytAPIListDevices, nil)
+	if err != nil {
+		fmt.Printf("creating GET request: %v\n", err)
+		os.Exit(1)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiToken))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("listing devices from API: %v\n", err)
+		os.Exit(1)
+	}
+
+	if resp.StatusCode != 200 {
+		fmt.Printf("Tidbyt API returned status %s\n", resp.Status)
+		body, _ := ioutil.ReadAll(resp.Body)
+		fmt.Println(string(body))
+		os.Exit(1)
+	}
+
+	body := struct {
+		Devices []struct {
+			ID string `json:"id"`
+		} `json:"devices"`
+	}{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		fmt.Println("decoding API response:", err)
+		os.Exit(1)
+	}
+
+	for _, d := range body.Devices {
+		fmt.Println(d.ID)
+	}
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -10,7 +10,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -60,27 +59,7 @@ func push(cmd *cobra.Command, args []string) {
 	}
 
 	if apiToken == "" {
-		var tok oauth2.Token
-		if err := privateConfig.UnmarshalKey("token", &tok); err != nil {
-			fmt.Println("unmarshaling API token from config:", err)
-			os.Exit(1)
-		}
-
-		if !tok.Valid() {
-			// probably expired, try to refresh
-			ts := oauthConf.TokenSource(cmd.Context(), &tok)
-			refreshed, err := ts.Token()
-			if err != nil {
-				fmt.Println("refreshing API token:", err)
-				os.Exit(1)
-			}
-
-			tok = *refreshed
-			privateConfig.Set("token", tok)
-			privateConfig.WriteConfig()
-		}
-
-		apiToken = tok.AccessToken
+		apiToken = oauthTokenFromConfig(cmd.Context())
 	}
 
 	if apiToken == "" {

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func init() {
 	rootCmd.AddCommand(cmd.VersionCmd)
 	rootCmd.AddCommand(cmd.ProfileCmd)
 	rootCmd.AddCommand(cmd.LoginCmd)
+	rootCmd.AddCommand(cmd.DevicesCmd)
 }
 
 func main() {


### PR DESCRIPTION
After logging in with `pixlet login`, you can use `pixlet devices` to list all of your devices.