### PR TITLE
Return nodes from XPath queries

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -106,6 +106,10 @@ On an xpath object, the following methods are available:
 | --- | --- |
 | `query(path)` | Retrieves text of the first tag matching the path |
 | `query_all(path)` | Retrieves text of all tags matching the path |
+| `query_node(path)` | Retrieves the first tag matching the path as an xpath object |
+| `query_all_nodes(path)` | Retrieves all tags matching the path as xpath objects |
+
+The `query_node` and `query_all_nodes` methods allow you to recursively query the XML document, which can be useful if you need to query several tags that are nested underneath some parent tag.
 
 Example:
 
@@ -122,6 +126,11 @@ doc = """
 def get_bars():
     x = xpath.loads(doc)
     return x.query_all("/foo/bar")
+
+def also_get_bars():
+    x = xpath.loads(doc)
+    foo = x.query_node("/foo")
+    return foo.query_all("/bar")
 ...
 ```
 

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -29,6 +29,7 @@ import (
 	"tidbyt.dev/pixlet/runtime/modules/random"
 	"tidbyt.dev/pixlet/runtime/modules/render_runtime"
 	"tidbyt.dev/pixlet/runtime/modules/sunrise"
+	"tidbyt.dev/pixlet/runtime/modules/xpath"
 	"tidbyt.dev/pixlet/schema"
 	"tidbyt.dev/pixlet/starlarkutil"
 )
@@ -307,7 +308,7 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 		return LoadSecretModule()
 
 	case "xpath.star":
-		return LoadXPathModule()
+		return xpath.LoadXPathModule()
 
 	case "compress/gzip.star":
 		return starlark.StringDict{

--- a/runtime/applet_test.go
+++ b/runtime/applet_test.go
@@ -262,49 +262,4 @@ def main():
 	assert.Equal(t, "foobar", printedText)
 }
 
-func TestXPathModule(t *testing.T) {
-	src := `
-load("render.star", r="render")
-load("xpath.star", "xpath")
-
-def main():
-    xml = """
-<foo>
-   <bar>1337</bar>
-   <bar>4711</bar>
-</foo>
-"""
-
-    d = xpath.loads(xml)
-
-    t = d.query("/foo/bar")
-    if t != "1337":
-        fail(t)
-
-    t = d.query_all("/foo/bar")
-    if len(t) != 2:
-        fail(len(t))
-    if t[0] != "1337":
-        fail(t[0])
-    if t[1] != "4711":
-        fail(t[1])
-
-    t = d.query("/foo/doesntexist")
-    if t != None:
-        fail(t)
-
-    t = d.query_all("/foo/doesntexist")
-    if len(t) != 0:
-        fail(t)
-
-    return [r.Root(child=r.Text("1337"))]
-`
-	app := &Applet{}
-	err := app.Load("test.star", []byte(src), nil)
-	assert.NoError(t, err)
-	screens, err := app.Run(map[string]string{})
-	assert.NoError(t, err)
-	assert.NotNil(t, screens)
-}
-
 // TODO: test Screens, especially Screens.Render()

--- a/runtime/modules/xpath/xpath.go
+++ b/runtime/modules/xpath/xpath.go
@@ -12,9 +12,11 @@ import (
 )
 
 type XPath struct {
-	doc      *xmlquery.Node
-	query    *starlark.Builtin
-	queryAll *starlark.Builtin
+	doc           *xmlquery.Node
+	query         *starlark.Builtin
+	queryAll      *starlark.Builtin
+	queryNode     *starlark.Builtin
+	queryAllNodes *starlark.Builtin
 }
 
 var (
@@ -54,12 +56,46 @@ func xPathLoads(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	}
 
 	x := &XPath{
-		doc:      doc,
-		query:    starlark.NewBuiltin("query", xPathQuery),
-		queryAll: starlark.NewBuiltin("query_all", xPathQueryAll),
+		doc:           doc,
+		query:         starlark.NewBuiltin("query", xPathQuery),
+		queryAll:      starlark.NewBuiltin("query_all", xPathQueryAll),
+		queryNode:     starlark.NewBuiltin("query_node", xPathQueryNode),
+		queryAllNodes: starlark.NewBuiltin("query_all_node", xPathQueryAllNodes),
 	}
 
 	return x, nil
+}
+
+func xPathQueryNode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path starlark.String
+
+	if err := starlark.UnpackArgs(
+		"query",
+		args, kwargs,
+		"path", &path,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for query: %v", err)
+	}
+
+	x := b.Receiver().(*XPath)
+
+	node, err := xmlquery.Query(x.doc, path.GoString())
+	if err != nil {
+		return nil, fmt.Errorf("querying: %v", err)
+	}
+
+	if node == nil {
+		return starlark.None, nil
+	}
+
+	result := &XPath{
+		doc:           node,
+		query:         starlark.NewBuiltin("query", xPathQuery),
+		queryAll:      starlark.NewBuiltin("query_all", xPathQueryAll),
+		queryNode:     starlark.NewBuiltin("query_node", xPathQueryNode),
+		queryAllNodes: starlark.NewBuiltin("query_all_node", xPathQueryAllNodes),
+	}
+	return result, nil
 }
 
 func xPathQuery(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -83,8 +119,40 @@ func xPathQuery(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tupl
 	if node == nil {
 		return starlark.None, nil
 	}
-
 	return starlark.String(node.InnerText()), nil
+}
+
+func xPathQueryAllNodes(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var path starlark.String
+
+	if err := starlark.UnpackArgs(
+		"query_all",
+		args, kwargs,
+		"path", &path,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for query_all: %v", err)
+	}
+
+	x := b.Receiver().(*XPath)
+
+	nodes, err := xmlquery.QueryAll(x.doc, path.GoString())
+	if err != nil {
+		return nil, fmt.Errorf("querying all: %v", err)
+	}
+
+	results := make([]starlark.Value, 0, len(nodes))
+	for _, n := range nodes {
+		result := &XPath{
+			doc:           n,
+			query:         starlark.NewBuiltin("query", xPathQuery),
+			queryAll:      starlark.NewBuiltin("query_all", xPathQueryAll),
+			queryNode:     starlark.NewBuiltin("query_node", xPathQueryNode),
+			queryAllNodes: starlark.NewBuiltin("query_all_node", xPathQueryAllNodes),
+		}
+		results = append(results, result)
+	}
+
+	return starlark.NewList(results), nil
 }
 
 func xPathQueryAll(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -117,6 +185,8 @@ func (x *XPath) AttrNames() []string {
 	return []string{
 		"query",
 		"query_all",
+		"query_node",
+		"query_all_nodes",
 	}
 }
 
@@ -128,6 +198,12 @@ func (x *XPath) Attr(name string) (starlark.Value, error) {
 
 	case "query_all":
 		return x.queryAll.BindReceiver(x), nil
+
+	case "query_node":
+		return x.queryNode.BindReceiver(x), nil
+
+	case "query_all_nodes":
+		return x.queryAllNodes.BindReceiver(x), nil
 
 	default:
 		return nil, nil

--- a/runtime/modules/xpath/xpath.go
+++ b/runtime/modules/xpath/xpath.go
@@ -1,8 +1,7 @@
-package runtime
+package xpath
 
 import (
 	"fmt"
-	//	"log"
 	"strings"
 	"sync"
 

--- a/runtime/modules/xpath/xpath_test.go
+++ b/runtime/modules/xpath/xpath_test.go
@@ -1,0 +1,54 @@
+package xpath_test
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "tidbyt.dev/pixlet/runtime"
+)
+
+func TestXPath(t *testing.T) {
+	src := `
+load("render.star", r="render")
+load("xpath.star", "xpath")
+
+def main():
+    xml = """
+<foo>
+   <bar>1337</bar>
+   <bar>4711</bar>
+</foo>
+"""
+
+    d = xpath.loads(xml)
+
+    t = d.query("/foo/bar")
+    if t != "1337":
+        fail(t)
+
+    t = d.query_all("/foo/bar")
+    if len(t) != 2:
+        fail(len(t))
+    if t[0] != "1337":
+        fail(t[0])
+    if t[1] != "4711":
+        fail(t[1])
+
+    t = d.query("/foo/doesntexist")
+    if t != None:
+        fail(t)
+
+    t = d.query_all("/foo/doesntexist")
+    if len(t) != 0:
+        fail(t)
+
+    return [r.Root(child=r.Text("1337"))]
+`
+	app := &runtime.Applet{}
+	err := app.Load("test.star", []byte(src), nil)
+	require.NoError(t, err)
+	screens, err := app.Run(map[string]string{})
+	require.NoError(t, err)
+	assert.NotNil(t, screens)
+}

--- a/runtime/modules/xpath/xpath_test.go
+++ b/runtime/modules/xpath/xpath_test.go
@@ -1,11 +1,11 @@
 package xpath_test
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "tidbyt.dev/pixlet/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tidbyt.dev/pixlet/runtime"
 )
 
 func TestXPath(t *testing.T) {
@@ -18,6 +18,13 @@ def main():
 <foo>
    <bar>1337</bar>
    <bar>4711</bar>
+   <baz>
+      <qux>999</qux>
+      <qux>888</qux>
+   </baz>
+   <baz>
+      <qux>777</qux>
+   </baz>
 </foo>
 """
 
@@ -42,6 +49,27 @@ def main():
     t = d.query_all("/foo/doesntexist")
     if len(t) != 0:
         fail(t)
+
+    n = d.query_node("/foo/baz")
+    t = n.query("/qux")
+    if t != "999":
+        fail(t)
+
+    n = d.query_all_nodes("/foo/baz")
+    if len(n) != 2:
+        fail(len(n))
+    t = n[0].query_all("/qux")
+    if len(t) != 2:
+        fail(len(t))
+    if t[0] != "999":
+        fail(t[0])
+    if t[1] != "888":
+        fail(t[1])
+    t = n[1].query_all("/qux")
+    if len(t) != 1:
+        fail(len(t))
+    if t[0] != "777":
+        fail(t[0])
 
     return [r.Root(child=r.Text("1337"))]
 `


### PR DESCRIPTION
This would have helped with the national rail app.

I was working with an API that returns XML. The response contained a list of items and I wanted to extract a few values from each item.

Say I am dealing with item `/foo/bar/baz[0]` and I want fields `qux` and `xyz` with in it.

Currently, I have to repeat the absolute path in every query -- `/foo/bar/baz[0]/qux` and `/foo/bar/baz[0]/xyz`. This also presumably means we have to do more work for each query because we walk the full length from the root to the leaf each time.

With this PR, it's possible to instead do one query first to get the node for the item -- `/foo/bar/baz[0]/` -- and then do smaller queries on that node -- simply `/qux` and `/xyz`.

Also does some refactoring to put the xpath module into a module folder like other modules, and move over the tests before I modified the code. This is adding two new methods rather than changing the return types of the existing ones, to avoid breaking apps.