### PR TITLE
devices: Print display name of each device

### DIFF
--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -51,7 +51,8 @@ func devices(cmd *cobra.Command, args []string) {
 
 	body := struct {
 		Devices []struct {
-			ID string `json:"id"`
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
 		} `json:"devices"`
 	}{}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -60,6 +61,6 @@ func devices(cmd *cobra.Command, args []string) {
 	}
 
 	for _, d := range body.Devices {
-		fmt.Println(d.ID)
+		fmt.Printf("%s (%s)\n", d.ID, d.DisplayName)
 	}
 }


### PR DESCRIPTION
In `pixlet devices`, print the display name of each device. This is handy if you have multiple devices and want to be able to distinguish between them.