### PR TITLE
feat: Add Windows build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
         id: vars
         shell: msys2 {0}
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        if: matrix.os == 'windows-latest'
 
       - name: Build Release Linux
         if: matrix.os == 'ubuntu-latest'
@@ -114,6 +114,7 @@ jobs:
 
       - name: Build Release Windows
         if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
         run: make release-windows
         env:
           PIXLET_VERSION: ${{ steps.vars.outputs.tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build and Test Release Artifacts
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -42,6 +42,17 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          update: true
+          install: >-
+            make
+            mingw-w64-x86_64-go
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-libwebp
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -62,13 +73,32 @@ jobs:
 
       - name: Build
         run: make build
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+
+      - name: Build Windows
+        shell: msys2 {0}
+        run: make build
+        if: matrix.os == 'windows-latest'
 
       - name: Test
         run: make test
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+
+      - name: Test Windows
+        shell: msys2 {0}
+        run: make test
+        if: matrix.os == 'windows-latest'
 
       - name: Set pixlet version
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+
+      - name: Set Windows pixlet version
+        id: vars
+        shell: msys2 {0}
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
 
       - name: Build Release Linux
         if: matrix.os == 'ubuntu-latest'
@@ -79,6 +109,12 @@ jobs:
       - name: Build Release macOS
         if: matrix.os == 'macos-latest'
         run: make release-macos
+        env:
+          PIXLET_VERSION: ${{ steps.vars.outputs.tag }}
+
+      - name: Build Release Windows
+        if: matrix.os == 'windows-latest'
+        run: make release-windows
         env:
           PIXLET_VERSION: ${{ steps.vars.outputs.tag }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Build Release Windows
         if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
         run: make release-windows
         env:
           PIXLET_VERSION: 0.0.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           update: true
           install: >-
+            make
             mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-libwebp

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -78,6 +78,13 @@ jobs:
         run: make build
         if: matrix.os == 'windows-latest'
 
+      - name: Upload Windows Artifacts
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'windows-latest'
+        with:
+          name: windows-artifacts
+          path: pixlet.exe
+
       - name: Test
         run: make test
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -78,12 +78,18 @@ jobs:
         run: make build
         if: matrix.os == 'windows-latest'
 
+      - name: Build Release Windows
+        if: matrix.os == 'windows-latest'
+        run: make release-windows
+        env:
+          PIXLET_VERSION: 0.0.1
+
       - name: Upload Windows Artifacts
         uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: windows-artifacts
-          path: pixlet.exe
+          path: build
 
       - name: Test
         run: make test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -78,20 +78,6 @@ jobs:
         run: make build
         if: matrix.os == 'windows-latest'
 
-      - name: Build Release Windows
-        if: matrix.os == 'windows-latest'
-        shell: msys2 {0}
-        run: make release-windows
-        env:
-          PIXLET_VERSION: 0.0.1
-
-      - name: Upload Windows Artifacts
-        uses: actions/upload-artifact@v3
-        if: matrix.os == 'windows-latest'
-        with:
-          name: windows-artifacts
-          path: build
-
       - name: Test
         run: make test
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,6 +41,16 @@ jobs:
         with:
           node-version: "16"
 
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          update: true
+          install: >-
+            mingw-w64-x86_64-go
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-libwebp
+
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -60,6 +70,18 @@ jobs:
 
       - name: Build
         run: make build
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+
+      - name: Build Windows
+        shell: msys2 {0}
+        run: make build
+        if: matrix.os == 'windows-latest'
 
       - name: Test
         run: make test
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+
+      - name: Test Windows
+        shell: msys2 {0}
+        run: make test
+        if: matrix.os == 'windows-latest'

--- a/.goreleaser/fetch-artifacts.sh
+++ b/.goreleaser/fetch-artifacts.sh
@@ -7,3 +7,7 @@ for dist in "darwin_amd64" "linux_amd64" "darwin_arm64" "linux_arm64"; do
     cp "$dist/pixlet" "out/pixlet_$dist/pixlet"
     chmod +x "out/pixlet_$dist/pixlet"
 done
+
+dist="windows_amd64"
+mkdir -p "out/pixlet_$dist"
+cp "$dist/pixlet.exe" "out/pixlet_$dist/pixlet.exe"

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ release-macos: clean
 release-linux: clean
 	./scripts/release-linux.sh
 
+release-windows: clean
+	./scripts/release-windows.sh
+
 install-buildifier:
 	go install github.com/bazelbuild/buildtools/buildifier@latest
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,12 +21,16 @@ do
 	echo "Building ${RELEASE_PLATFORM}_${RELEASE_ARCH}"
 
 	if [[ $ARCH == "linux-arm64"  ]]; then
+		echo "linux-arm64"
 		 CC=aarch64-linux-gnu-gcc CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "linux-amd64"  ]]; then
+		echo "linux-amd64"
 		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "windows-amd64"  ]]; then
+		echo "windows-amd64"
 		go build -ldflags="-s -extldflags=-static-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
 	else
+		echo "other"
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	fi
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -28,7 +28,7 @@ do
 		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "windows-amd64"  ]]; then
 		echo "windows-amd64"
-		go build -ldflags="-s -extldflags=-static-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
+		go build -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
 	else
 		echo "other"
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -25,7 +25,7 @@ do
 	elif [[ $ARCH == "linux-amd64"  ]]; then
 		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "windows-amd64"  ]]; then
-		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-s -extldflags=-static-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
+		go build -ldflags="-s -extldflags=-static-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
 	else
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	fi

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -24,6 +24,8 @@ do
 		 CC=aarch64-linux-gnu-gcc CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "linux-amd64"  ]]; then
 		 CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+	elif [[ $ARCH == "windows-amd64"  ]]; then
+		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-s -extldflags=-static-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
 	else
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	fi

--- a/scripts/release-linux.sh
+++ b/scripts/release-linux.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RELEASE_ARCHS="linux-x86-64 linux-arm64"
+export RELEASE_ARCHS="linux-amd64 linux-arm64"
 export RELEASE_PLATFORM="linux"
 
 source scripts/build-release.sh

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RELEASE_ARCHS="mac-arm64 mac-x86-64"
+export RELEASE_ARCHS="darwim-arm64 darwin-amd64"
 export RELEASE_PLATFORM="darwin"
 
 source scripts/set-libwebp-version.sh

--- a/scripts/release-windows.sh
+++ b/scripts/release-windows.sh
@@ -5,6 +5,4 @@ set -e
 export RELEASE_ARCHS="windows-x86_64"
 export RELEASE_PLATFORM="windows"
 
-source scripts/set-libwebp-version.sh
-source scripts/fetch-deps.sh
 source scripts/build-release.sh

--- a/scripts/release-windows.sh
+++ b/scripts/release-windows.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export RELEASE_ARCHS="windows-x86_64"
+export RELEASE_ARCHS="windows-amd64"
 export RELEASE_PLATFORM="windows"
 
 source scripts/build-release.sh

--- a/scripts/release-windows.sh
+++ b/scripts/release-windows.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+export RELEASE_ARCHS="windows-x86_64"
+export RELEASE_PLATFORM="windows"
+
+source scripts/set-libwebp-version.sh
+source scripts/fetch-deps.sh
+source scripts/build-release.sh


### PR DESCRIPTION
# Overview
This change adds a statically linked Windows executable to our build and release process. It's still not super friendly - the result of this change is `pixlet.exe` will be available for download on the GitHub release. The things we really need are either [chocolatey](https://chocolatey.org/) or create an MSI installer or both so that folks can install pixlet without having to find a home for the program manually on their system. However, this sure beats having to build it from source 😅 .

# Additional
This change might actually fix some issues with statically linking linux binaries. I realized my build script was broken, and we were defaulting to the MacOS build instead of the linux ones which would explain the issue where Linux binaries are not being statically linked.

# Tests
![Screenshot 2022-10-29 114250](https://user-images.githubusercontent.com/3886576/198841051-125b224a-42a8-449a-adb0-153f3caa6e82.png)
![Screenshot 2022-10-29 114321](https://user-images.githubusercontent.com/3886576/198841052-afc567a3-871a-4d44-b99f-e964500b1294.png)
