### PR TITLE
build: Fix goreleaser.

### DIFF
--- a/.goreleaser/fetch-artifacts.sh
+++ b/.goreleaser/fetch-artifacts.sh
@@ -2,12 +2,14 @@
 
 set -euo pipefail
 
-for dist in "darwin_amd64" "linux_amd64" "darwin_arm64" "linux_arm64"; do
+for dist in "darwin_amd64" "linux_amd64" "darwin_arm64" "linux_arm64" "windows_amd64"; do
     mkdir -p "out/pixlet_$dist"
-    cp "$dist/pixlet" "out/pixlet_$dist/pixlet"
-    chmod +x "out/pixlet_$dist/pixlet"
-done
+	if [[ $dist == "windows_amd64"  ]]; then
+        cp "$dist/pixlet.exe" "out/pixlet_$dist/pixlet.exe"
+	else
+        cp "$dist/pixlet" "out/pixlet_$dist/pixlet"
+        chmod +x "out/pixlet_$dist/pixlet"
+	fi
 
-dist="windows_amd64"
-mkdir -p "out/pixlet_$dist"
-cp "$dist/pixlet.exe" "out/pixlet_$dist/pixlet.exe"
+    rm -rf "$dist"
+done


### PR DESCRIPTION
This commit fixes an issue where the windows output dir stays around causing goreleaser to think something modified the git directory.