### PR TITLE
build: Fix gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ examples/*.gif
 
 # Pixlet Binary
 pixlet
+pixlet.exe
 
 # Releases
 build/

--- a/.goreleaser/fetch-artifacts.sh
+++ b/.goreleaser/fetch-artifacts.sh
@@ -10,6 +10,4 @@ for dist in "darwin_amd64" "linux_amd64" "darwin_arm64" "linux_arm64" "windows_a
         cp "$dist/pixlet" "out/pixlet_$dist/pixlet"
         chmod +x "out/pixlet_$dist/pixlet"
 	fi
-
-    rm -rf "$dist"
 done


### PR DESCRIPTION
This commit should actually resolve the dirty state issue with goreleaser. It wasn't that the directory was left behind, it was that the directory existed when goreleaser started. The reason the others were ok was because these directories only have one file. However, we never ignored the `.exe` version of pixlet.