### PR TITLE
build: Fix goreleaser os selection.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,11 +7,20 @@ builds:
       - amd64
       - arm64
 
+    goos:
+      - darwin
+      - linux
+      - windows
+
+    ignore:
+      - goos: windows
+        goarch: arm64
+
     hooks:
       post: ./.goreleaser/fetch-artifacts.sh
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 changelog:
   sort: asc


### PR DESCRIPTION
I had no idea goreleaser defaulted to darwin/linux, so I had no idea I needed to add windows :D. This commit sets the goos explicitely. In addition, I made sure arm64 for windows was not supported at the moment.