### PR TITLE
build: Fix macOS intel based release.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,12 +8,24 @@ builds:
   - builder: prebuilt
     binary: pixlet
 
-    targets:
-      - darwin_amd64
-      - darwin_arm64
-      - linux_amd64
-      - linux_arm64
-      - windows_amd64
+    goarch:
+      - amd64
+      - arm64
+
+    goos:
+      - darwin
+      - linux
+      - windows
+
+    goarm:
+      - 7
+
+    goamd64:
+      - v1
+
+    ignore:
+      - goos: windows
+        goarch: arm64
 
     prebuilt:
       path: build/{{ .Os }}_{{ .Arch }}/pixlet{{ .Ext }}


### PR DESCRIPTION
# Overview
GoReleaser has two mode: the normal mode of operation and "prebuilt". Ideally, we will get ourselves into a state where GoReleaser can handle it all. In the short term, we're relying on "prebuilt" which comes with a ton of gotchas. Most notably, all bets are off with how you configure the build and how subsequent steps will handle the resulting artifacts. They do provide some call outs here, but it's been difficult to reason about until there is a bad release 😭 

# Changes
- [build: Fix macOS intel based release.](https://github.com/tidbyt/pixlet/commit/714cde8067549ebea7a0722d186da69a4ab93543)
    - This commit fixes the macOS intel based home brew release. The overview is that GoReleaser sets these variables and expects them all to exist. However, when we switch to the prebuilt mode, most assumptions GoReleaser makes goes out the window. The docs do say that these variables will not be set and we have to define them ourselves, but the list of targets felt just fine at the time. The issue is, the hombrew logic expects these variables to exist and not just a list of targets. I added back the old format and added in the defaults of the other variables that are no longer set.

# Tests
```
 goreleaser release --snapshot --rm-dist
 ```
 
 Curled an [older version of pixlet.rb](*https://raw.githubusercontent.com/tidbyt/homebrew-tidbyt/3cf07292a08097da1d0c9441bea8e142e303dc5a/pixlet.rb) to compare against.

```diff
 diff pixlet.rb out/pixlet.rb 
8c8,10
<   version "0.22.4"
---
>   version "0.22.5-SNAPSHOT-7064dab"
> 
>   depends_on "webp"
12,13c14,15
<       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.4/pixlet_0.22.4_darwin_arm64.tar.gz"
<       sha256 "eadaaccfb53c45d56e90bcb005d180e48c6665332d1f775bf660a7c5f1188d23"
---
>       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.5/pixlet_0.22.5-SNAPSHOT-7064dab_darwin_arm64.tar.gz"
>       sha256 "e88c5ec6ba6f0323f08e6d75692f0714ce0940d6d58b60c965b998e130c45bcd"
20,21c22,23
<       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.4/pixlet_0.22.4_darwin_amd64.tar.gz"
<       sha256 "06b49cab038f95e8313a38be7707c1b0a5a83bf0c475d0e3a71d57197ae8eefa"
---
>       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.5/pixlet_0.22.5-SNAPSHOT-7064dab_darwin_amd64.tar.gz"
>       sha256 "e69a50d7416dd33776b9e345bbf36a8e8b699521bb0d7239fa295904261db730"
31,32c33,34
<       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.4/pixlet_0.22.4_linux_arm64.tar.gz"
<       sha256 "1fb296f983dd75d24884861283058ce5a9d5d99508ca950e8a7735e235bae761"
---
>       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.5/pixlet_0.22.5-SNAPSHOT-7064dab_linux_arm64.tar.gz"
>       sha256 "1bc3b34fab848cd4209a280f3affcfc0c1d4502dbae990ac7458aa7a4522b5af"
39,40c41,42
<       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.4/pixlet_0.22.4_linux_amd64.tar.gz"
<       sha256 "a5e65dedde3b21607cd6eb40327969f393b648c9c3d22df9c00a46efc9195ebb"
---
>       url "https://github.com/tidbyt/pixlet/releases/download/v0.22.5/pixlet_0.22.5-SNAPSHOT-7064dab_linux_amd64.tar.gz"
>       sha256 "e2d44f41879e64edfe9055b4e0bab93c0838dd22514fff884d1ec17805b46c7e"
47,48d48
< 
<   depends_on "webp"
< 
```