### PR TITLE
bugfix: Fix image magnification.

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -106,8 +106,8 @@ func render(cmd *cobra.Command, args []string) {
 		)
 		for x := 0; x < in.Bounds().Dx(); x++ {
 			for y := 0; y < in.Bounds().Dy(); y++ {
-				for xx := 0; xx < 10; xx++ {
-					for yy := 0; yy < 10; yy++ {
+				for xx := 0; xx < magnify; xx++ {
+					for yy := 0; yy < magnify; yy++ {
 						out.SetRGBA(
 							x*magnify+xx,
 							y*magnify+yy,


### PR DESCRIPTION
This commit fixes an issue with image magnification where sizes greater than 10 would leave transparent pixels between pixels.

# Bad
![day_night_map-1](https://user-images.githubusercontent.com/3886576/200375057-1bafb153-6de0-45af-8799-b7132ac2c140.gif)


# Good
![day_night_map](https://user-images.githubusercontent.com/3886576/200374819-2417d8b9-7c54-4dff-9b60-0d0363262f39.gif)


# Tests
The following commands, as well as visual diffs of each run:
```
./pixlet render ../community/apps/daynightmap/day_night_map.star -m 10
identify ../community/apps/daynightmap/day_night_map.webp  
../community/apps/daynightmap/day_night_map.webp WEBP 640x320 640x320+0+0 8-bit sRGB 3694B 0.000u 0:00.000
```

```
./pixlet render ../community/apps/daynightmap/day_night_map.star -m 100
identify ../community/apps/daynightmap/day_night_map.webp              
../community/apps/daynightmap/day_night_map.webp WEBP 6400x3200 6400x3200+0+0 8-bit sRGB 11886B 0.000u 0:00.000
```

```
./pixlet render ../community/apps/daynightmap/day_night_map.star -m 2  
identify ../community/apps/daynightmap/day_night_map.webp            
../community/apps/daynightmap/day_night_map.webp WEBP 128x64 128x64+0+0 8-bit sRGB 3598B 0.000u 0:00.000
```