### PR TITLE
Added instructions to README to install the latest pixlet binary using the Arch User Repository on linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ brew install tidbyt/tidbyt/pixlet
 
 Download the `pixlet` binary from [the latest release][1].
 
+Arch Linux users can install the latest pixlet binary from the [Arch User Repository (AUR)](https://aur.archlinux.org/packages/pixlet-bin) using [yay](https://github.com/Jguer/yay):
+```
+yay -S pixlet-bin
+```
+
 Alternatively you can [build from source](docs/BUILD.md).
 
 [1]: https://github.com/tidbyt/pixlet/releases/latest


### PR DESCRIPTION
Greetings tidbyt team! I recently added a package to the popular Arch Linux Repository for the pixlet binary: https://aur.archlinux.org/packages/pixlet-bin. -- it downloads and installs the latest release binary from GitHub automatically, and auto-updates as well. It's sourced directly from your GitHub repo.

I've updated the README of this repo to include instructions for Arch Linux users.

Please feel free to merge or reject at your discretion!