### PR TITLE
add Root.show_full_animation for overriding app cycle speed

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -328,6 +328,7 @@ displaying stale data in the event of e.g. connectivity issues.
 | `child` | `Widget` | Widget to render | **Y** |
 | `delay` | `int` | Frame delay in milliseconds | N |
 | `max_age` | `int` | Expiration time in seconds | N |
+| `show_full_animation` | `bool` | Request animation is shown in full, regardless of app cycle speed | N |
 
 
 

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -26,10 +26,11 @@ const (
 )
 
 type Screens struct {
-	roots  []render.Root
-	images []image.Image
-	delay  int32
-	MaxAge int32
+	roots             []render.Root
+	images            []image.Image
+	delay             int32
+	MaxAge            int32
+	ShowFullAnimation bool
 }
 
 type ImageFilter func(image.Image) (image.Image, error)
@@ -47,6 +48,7 @@ func ScreensFromRoots(roots []render.Root) *Screens {
 		if roots[0].MaxAge > 0 {
 			screens.MaxAge = roots[0].MaxAge
 		}
+		screens.ShowFullAnimation = roots[0].ShowFullAnimation
 	}
 	return &screens
 }

--- a/encode/encode_test.go
+++ b/encode/encode_test.go
@@ -227,3 +227,27 @@ func TestScreensFromRoots(t *testing.T) {
 	assert.Equal(t, int32(4711), s.delay)
 	assert.Equal(t, int32(42), s.MaxAge)
 }
+
+func TestShowFullAnimation(t *testing.T) {
+	requestFull := `
+load("render.star", "render")
+def main():
+    return render.Root(show_full_animation=True, child=render.Box())
+`
+	app := runtime.Applet{}
+	require.NoError(t, app.Load("test.star", []byte(requestFull), nil))
+	roots, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.True(t, ScreensFromRoots(roots).ShowFullAnimation)
+
+	dontRequestFull := `
+load("render.star", "render")
+def main():
+    return render.Root(child=render.Box())
+`
+	app = runtime.Applet{}
+	require.NoError(t, app.Load("test.star", []byte(dontRequestFull), nil))
+	roots, err = app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.False(t, ScreensFromRoots(roots).ShowFullAnimation)
+}

--- a/render/root.go
+++ b/render/root.go
@@ -37,11 +37,12 @@ const (
 // DOC(Child): Widget to render
 // DOC(Delay): Frame delay in milliseconds
 // DOC(MaxAge): Expiration time in seconds
-//
+// DOC(ShowFullAnimation): Request animation is shown in full, regardless of app cycle speed
 type Root struct {
-	Child  Widget `starlark:"child,required"`
-	Delay  int32  `starlark:"delay"`
-	MaxAge int32  `starlark:"max_age"`
+	Child             Widget `starlark:"child,required"`
+	Delay             int32  `starlark:"delay"`
+	MaxAge            int32  `starlark:"max_age"`
+	ShowFullAnimation bool   `starlark:"show_full_animation"`
 
 	maxParallelFrames int
 	maxFrameCount     int

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -1174,9 +1174,10 @@ func newRoot(
 ) (starlark.Value, error) {
 
 	var (
-		child   starlark.Value
-		delay   starlark.Int
-		max_age starlark.Int
+		child               starlark.Value
+		delay               starlark.Int
+		max_age             starlark.Int
+		show_full_animation starlark.Bool
 	)
 
 	if err := starlark.UnpackArgs(
@@ -1185,6 +1186,7 @@ func newRoot(
 		"child", &child,
 		"delay?", &delay,
 		"max_age?", &max_age,
+		"show_full_animation?", &show_full_animation,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Root: %s", err)
 	}
@@ -1215,6 +1217,8 @@ func newRoot(
 		return nil, err
 	}
 
+	w.ShowFullAnimation = bool(show_full_animation)
+
 	return w, nil
 }
 
@@ -1224,7 +1228,7 @@ func (w *Root) AsRenderRoot() render.Root {
 
 func (w *Root) AttrNames() []string {
 	return []string{
-		"child", "delay", "max_age",
+		"child", "delay", "max_age", "show_full_animation",
 	}
 }
 
@@ -1242,6 +1246,10 @@ func (w *Root) Attr(name string) (starlark.Value, error) {
 	case "max_age":
 
 		return starlark.MakeInt(int(w.MaxAge)), nil
+
+	case "show_full_animation":
+
+		return starlark.Bool(w.ShowFullAnimation), nil
 
 	default:
 		return nil, nil


### PR DESCRIPTION
Tidbyt devices rotate between installed apps according to a user configured app cycle speed. If an animation is still running when it's time to switch app, the animation will be cut off. This PR adds a flag to request that the animation is instead displayed in full, disregarding the app cycle speed.