### PR TITLE
Disable some lint warnings.

### DIFF
--- a/cmd/buildifier.go
+++ b/cmd/buildifier.go
@@ -168,11 +168,13 @@ var disabledWarnings = map[string]bool{
 	"function-docstring-header": true, // disables docstring warnings
 	"function-docstring-args":   true, // disables docstring warnings
 	"function-docstring-return": true, // disables docstring warnings
+	"name-conventions":          true, // disables naming convention warnings
 	"native-android":            true, // disables native android rules
 	"native-cc":                 true, // disables native cc rules
 	"native-java":               true, // disables native java rules
 	"native-proto":              true, // disables native proto rules
 	"native-py":                 true, // disables native python rules
+	"unsorted-dict-items":       true, // disables dictionary sorting
 }
 
 // processFile processes a single file containing data.


### PR DESCRIPTION
This commit disables lint warnings for unsorted dictionaries and naming conventions. For dicts, the issue is there are a lot of dictionaries that are logcially sorted in code and this would rewrite all of them. For the naming, we have 2.8K naming convention violations in the community repo so it would be really hard to enforce the other linters if we didn't fix those first.