### PR TITLE
Remove integer-division linter.

### DIFF
--- a/cmd/buildifier.go
+++ b/cmd/buildifier.go
@@ -168,6 +168,7 @@ var disabledWarnings = map[string]bool{
 	"function-docstring-header": true, // disables docstring warnings
 	"function-docstring-args":   true, // disables docstring warnings
 	"function-docstring-return": true, // disables docstring warnings
+	"integer-division":          true, // disables integer division
 	"name-conventions":          true, // disables naming convention warnings
 	"native-android":            true, // disables native android rules
 	"native-cc":                 true, // disables native cc rules


### PR DESCRIPTION
This commit disables the integer division linter that is changing quite a few lines in the community repo. The issue is, I can't say for certain if the values are integers or not, making the change potentially unsafe. I am disabling it instead.