### PR TITLE
Disable string-iteration warning.

### DIFF
--- a/cmd/buildifier.go
+++ b/cmd/buildifier.go
@@ -175,6 +175,7 @@ var disabledWarnings = map[string]bool{
 	"native-java":               true, // disables native java rules
 	"native-proto":              true, // disables native proto rules
 	"native-py":                 true, // disables native python rules
+	"string-iteration":          true, // disables string iteration warning
 	"unsorted-dict-items":       true, // disables dictionary sorting
 }
 


### PR DESCRIPTION
This commit disables string-iteration warning for the linter. Iterating over a string is natural in python, and the proposed solution of ranging over the length of the string and using the index does not feel natural.