### PR TITLE
Remove confusing name warning.

### DIFF
--- a/cmd/buildifier.go
+++ b/cmd/buildifier.go
@@ -164,6 +164,7 @@ func defaultWarnings() []string {
 }
 
 var disabledWarnings = map[string]bool{
+	"confusing-name":            true, // disables confusing name warnings
 	"function-docstring":        true, // disables docstring warnings
 	"function-docstring-header": true, // disables docstring warnings
 	"function-docstring-args":   true, // disables docstring warnings


### PR DESCRIPTION
This commit removes the confusing name warning. In the community repo, the only offenders are the hue/saturation/lightness methods which feel like they made the right call. Typing "lightness" everywhere to avoid L doesn't really make sense.