### PR TITLE
feat: Standardize error handling.

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/bazelbuild/buildtools/differ"
 	"github.com/spf13/cobra"
@@ -23,10 +23,10 @@ var FormatCmd = &cobra.Command{
 will format your starlark source code in line. If you wish you see the output
 before applying, add the --dry-run flag.`,
 	Args: cobra.MinimumNArgs(1),
-	Run:  formatCmd,
+	RunE: formatCmd,
 }
 
-func formatCmd(cmd *cobra.Command, args []string) {
+func formatCmd(cmd *cobra.Command, args []string) error {
 	// Lint refers to the lint mode for buildifier, with the options being off,
 	// warn, or fix. For pixlet format, we don't want to lint at all.
 	lint := "off"
@@ -46,6 +46,10 @@ func formatCmd(cmd *cobra.Command, args []string) {
 	diff = differ
 
 	// Run buildifier and exit with the returned exit code.
-	exitCode := runBuildifier(args, lint, mode, "text", rflag, vflag)
-	os.Exit(exitCode)
+	exitCode := runBuildifier(args, lint, mode, "", rflag, vflag)
+	if exitCode != 0 {
+		return fmt.Errorf("formatting returned non-zero exit status: %d", exitCode)
+	}
+
+	return nil
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/bazelbuild/buildtools/differ"
 	"github.com/spf13/cobra"
@@ -11,7 +11,7 @@ func init() {
 	LintCmd.Flags().BoolVarP(&vflag, "verbose", "v", false, "print verbose information to standard error")
 	LintCmd.Flags().BoolVarP(&rflag, "recursive", "r", false, "find starlark files recursively")
 	LintCmd.Flags().BoolVarP(&fixFlag, "fix", "f", false, "automatically fix resolvable lint issues")
-	LintCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "output format, text or json")
+	LintCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "output format, text or json")
 }
 
 var LintCmd = &cobra.Command{
@@ -23,10 +23,10 @@ var LintCmd = &cobra.Command{
 file, a list of files, or directory with the recursive option. Additionally, it
 provides an option to automatically fix resolvable linter issues.`,
 	Args: cobra.MinimumNArgs(1),
-	Run:  lintCmd,
+	RunE: lintCmd,
 }
 
-func lintCmd(cmd *cobra.Command, args []string) {
+func lintCmd(cmd *cobra.Command, args []string) error {
 	// Mode refers to formatting mode for buildifier, with the options being
 	// check, diff, or fix. For the pixlet lint command, we only want to check
 	// formatting.
@@ -55,5 +55,9 @@ func lintCmd(cmd *cobra.Command, args []string) {
 
 	// Run buildifier and exit with the returned exit code.
 	exitCode := runBuildifier(args, lint, mode, outputFormat, rflag, vflag)
-	os.Exit(exitCode)
+	if exitCode != 0 {
+		return fmt.Errorf("linting failed with exit code: %d", exitCode)
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -10,9 +9,10 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   "pixlet",
-		Short: "pixel graphics rendering",
-		Long:  "Pixlet renders graphics for pixel devices, like Tidbyt",
+		Use:          "pixlet",
+		Short:        "pixel graphics rendering",
+		Long:         "Pixlet renders graphics for pixel devices, like Tidbyt",
+		SilenceUsage: true,
 	}
 )
 
@@ -32,7 +32,6 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This commit standardizes error handling to return an error from commands using RunE. In addition, it silences the usage on error so it's only our error message printed. This has a few benefits, but the one I'm after is being able to call commands from another command. For example, a `pixlet check` command that can call other commands and handle their output.