### PR TITLE
feat: Add app publish check command

### DIFF
--- a/cmd/buildifier.go
+++ b/cmd/buildifier.go
@@ -72,7 +72,9 @@ func runBuildifier(args []string, lint string, mode string, format string, recur
 	}
 
 	diagnosticsOutput := diagnostics.Format(format, verbose)
-	if format != "" {
+	if format == "off" {
+		// Do nothing.
+	} else if format != "" {
 		// Explicitly provided --format means the diagnostics are printed to stdout
 		fmt.Printf(diagnosticsOutput)
 		// Exit code should be set to 0 so that other tools know they can safely parse the json

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bazelbuild/buildtools/buildifier/utils"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	CheckCmd.Flags().BoolVarP(&rflag, "recursive", "r", false, "find apps recursively")
+}
+
+var CheckCmd = &cobra.Command{
+	Use:     "check <pathspec>...",
+	Example: `  pixlet check app.star`,
+	Short:   "Checks if an app is ready to publish",
+	Long: `The check command runs a series of checks to ensure your app is ready
+to publish in the community repo. Every failed check will have a solution
+provided. If your app fails a check, try the provided solution and reach out on
+Discord if you get stuck.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: checkCmd,
+}
+
+func checkCmd(cmd *cobra.Command, args []string) error {
+	// Use the same logic as buildifier to find relevant Tidbyt apps.
+	apps := args
+	if rflag {
+		discovered, err := utils.ExpandDirectories(&args)
+		if err != nil {
+			return fmt.Errorf("could not discover apps using recursive flag: %w", err)
+		}
+		apps = discovered
+	}
+
+	// Check every app.
+	foundIssue := false
+	for _, app := range apps {
+		// Check app formatting.
+		dryRunFlag = true
+		err := formatCmd(cmd, []string{app})
+		if err != nil {
+			foundIssue = true
+			failure(app, fmt.Errorf("app is not formatted correctly: %w", err), fmt.Sprintf("try `pixlet format %s`", app))
+			continue
+		}
+
+		// Create temporary file for app rendering.
+		f, err := os.CreateTemp("", "")
+		if err != nil {
+			return fmt.Errorf("could not create temp file for rendering, check your system: %w", err)
+		}
+		defer os.Remove(f.Name())
+
+		// Check if app will render.
+		silenceOutput = true
+		output = f.Name()
+		err = render(cmd, []string{app})
+		if err != nil {
+			foundIssue = true
+			failure(app, fmt.Errorf("app failed to render: %w", err), fmt.Sprintf("try `pixlet render %s` and resolve any errors", app))
+			continue
+		}
+
+		// Check if app is linted.
+		outputFormat = "off"
+		err = lintCmd(cmd, []string{app})
+		if err != nil {
+			foundIssue = true
+			failure(app, fmt.Errorf("app has lint warnings: %w", err), fmt.Sprintf("try `pixlet lint --fix %s`", app))
+			continue
+		}
+
+		success(app)
+	}
+
+	if foundIssue {
+		return fmt.Errorf("one or more apps failed checks")
+	}
+
+	return nil
+}
+
+func success(app string) {
+	c := color.New(color.FgGreen)
+	c.Printf("✔️ %s\n", app)
+}
+
+func failure(app string, err error, sol string) {
+	c := color.New(color.FgRed)
+	c.Printf("✖ %s\n", app)
+
+	// Ensure multiline errors are properly indented.
+	multilineError := strings.Split(err.Error(), "\n")
+	for index, line := range multilineError {
+		if index == 0 {
+			continue
+		}
+
+		// The builtin starlark Backtrace function prints the last line at an
+		// awkward indentation level. This check helps keep the failure indented
+		// at one more level to ensure it's even more clear what is broken.
+		if strings.Contains(line, "Error in") && index == len(multilineError)-1 {
+			multilineError[index] = fmt.Sprintf("      %s", line)
+		} else {
+			multilineError[index] = fmt.Sprintf("  %s", line)
+		}
+	}
+	problem := strings.Join(multilineError, "\n")
+
+	fmt.Printf("  ▪️ Problem: %v\n", problem)
+	fmt.Printf("  ▪️ Solution: %v\n", sol)
+}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -11,7 +11,7 @@ func init() {
 	LintCmd.Flags().BoolVarP(&vflag, "verbose", "v", false, "print verbose information to standard error")
 	LintCmd.Flags().BoolVarP(&rflag, "recursive", "r", false, "find starlark files recursively")
 	LintCmd.Flags().BoolVarP(&fixFlag, "fix", "f", false, "automatically fix resolvable lint issues")
-	LintCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "output format, text or json")
+	LintCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "output format: text, json, or off")
 }
 
 var LintCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bazelbuild/buildtools v0.0.0-20230113180850-180a94ab3a3a
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4
+	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/google/pprof v0.0.0-20230111200839-76d1ae5aea2b
@@ -36,7 +37,11 @@ require (
 	golang.org/x/sync v0.1.0
 )
 
-require github.com/chzyer/readline v1.5.0 // indirect
+require (
+	github.com/chzyer/readline v1.5.0 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+)
 
 require (
 	github.com/Code-Hex/go-wordwrap v1.0.0 // indirect
@@ -49,10 +54,10 @@ require (
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/gitsight/go-vcsurl v1.0.0 // indirect
+	github.com/gitsight/go-vcsurl v1.0.0
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.0 // indirect
-	github.com/go-git/go-git/v5 v5.5.2 // indirect
+	github.com/go-git/go-git/v5 v5.5.2
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
@@ -86,7 +91,7 @@ require (
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
-	golang.org/x/text v0.6.0 // indirect
+	golang.org/x/text v0.6.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4 h1:BBade+JlV/f7JstZ4pitd4tHhpN+w+6I+LyOS7B4fyU=
 github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4/go.mod h1:H7chHJglrhPPzetLdzBleF8d22WYOv7UM/lEKYiwlKM=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
@@ -303,6 +305,12 @@ github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPK
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -651,6 +659,7 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -676,7 +685,9 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func init() {
 	rootCmd.AddCommand(cmd.FormatCmd)
 	rootCmd.AddCommand(cmd.LintCmd)
 	rootCmd.AddCommand(cmd.CreateCmd)
+	rootCmd.AddCommand(cmd.CheckCmd)
 }
 
 func main() {


### PR DESCRIPTION
# Overview
Right now, new apps created via a pull request to the community repo require several checks to pass before an app is considered ready for merging. There are so many little snags along the way. We're working on ironing all of them out. For this change, the two problems we're looking to address are:
- The output from the build is really hard to read, so it's difficult to determine where you went wrong.
- The tools that run in the build are a bunch of tools tied together, which makes it hard to run locally when something fails.

This change introduces `pixlet check`, which will run a series of checks required to publish a new Tidbyt app. Not only can it be run locally, but it will be the tool running in CI.

# Demo
```
$ pixlet check examples/bitcoin.star     
✖ examples/bitcoin.star
  ▪️ Problem: app has lint warnings: linting failed with exit code: 4
  ▪️ Solution: try `pixlet lint --fix examples/bitcoin.star`
Error: one or more apps failed checks
```

Every problem should have an easy solution. In addition, that solution should be available through `pixlet`. Here is the output for a failed render:
```
$ pixlet check examples/bitcoin.star     
✖ examples/bitcoin.star
  ▪️ Problem: app failed to render: error running script: Traceback (most recent call last):
    examples/bitcoin.star:31:8: in main
    examples/bitcoin.star:16:9: in foo
      Error in fail: fail: it's broken
  ▪️ Solution: try `pixlet render examples/bitcoin.star` and resolve any errors
 ``` 
 
 # Next Steps
 Right now, the `pixlet check` command only checks if an app can render, if it's formatted correctly, and if it passes the linter. We need a few more checks:
 - We need to test the manifest to ensure all of our validation works as expected
     - Right now, this is a go unit test on a compiled go file :grimacing: . It likely means we should migrate away from the go based manifest before `pixlet check` can handle validation.
 - We test that all apps are registered
     - Same as above, but it runs a check based on directories and if it's registered or not 
 - We need to test spelling in the manifest to ensure there are no typos
     - Same issue as above, except we use a go based linter to run the checks.
 - We validate schema/icons
    - This is currently in a go unit test, but this feels like it can be added here without too much hassle.

# Changes
- [render: Add the ability to silence print statements.](https://github.com/tidbyt/pixlet/commit/4c40802b72b5a4da279df0b24a3cf584e67abd1c) 
    - This commit adds a `--silent` flag to silence print statements in Tidbyt apps.
- [lint: Add an option to turn output off.](https://github.com/tidbyt/pixlet/commit/b911236f578c6675ac2d789ba82fd0acd0e82e73) 
    - This commit adds an option to turn off the output. This is useful if we only care about if an app is linted or not, but don't care about the output.
- [feat: Add check command.](https://github.com/tidbyt/pixlet/commit/f32c4a64db249ca5d05de96a2e4783a65f42b1cc) 
    - This commit adds a check command to be able to ensure an app is ready for publishing.