### PR TITLE
feat: Community Target Determination

### DIFF
--- a/cmd/community/community.go
+++ b/cmd/community/community.go
@@ -1,0 +1,17 @@
+package community
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	CommunityCmd.AddCommand(TargetDeterminatorCmd)
+}
+
+var CommunityCmd = &cobra.Command{
+	Use:   "community",
+	Short: "Utilities to manage the community repo",
+	Long: `The community subcommand provides a set of utilities for managing the
+community repo. This subcommand should be considered slightly unstable in that
+we may determine a utility here should move to a more generalizable tool.`,
+}

--- a/cmd/community/targetdeterminator.go
+++ b/cmd/community/targetdeterminator.go
@@ -1,0 +1,49 @@
+package community
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"tidbyt.dev/pixlet/tools/repo"
+)
+
+var (
+	oldCommit string
+	newCommit string
+)
+
+func init() {
+	TargetDeterminatorCmd.Flags().StringVarP(&oldCommit, "old", "o", "", "The old commit to compare against")
+	TargetDeterminatorCmd.Flags().StringVarP(&newCommit, "new", "n", "", "The new commit to compare against")
+}
+
+var TargetDeterminatorCmd = &cobra.Command{
+	Use:   "target-determinator",
+	Short: "Determines what files have changed between old and new commit",
+	Example: `  pixlet community target-determinator \
+    --old 4d69e9bbf181434229a98e87909a619634072930 \
+    --new 2fc2a1fcfa48bbb0b836084c1b1e259322c4e133`,
+	Long: `This command determines what files have changed between two commits
+so that we can limit the build in the community repo to only the files that
+have changed.`,
+	RunE: determineTargets,
+}
+
+func determineTargets(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("could not determine targets, something went wrong with the local filesystem: %w", err)
+	}
+
+	files, err := repo.DetermineChanges(cwd, oldCommit, newCommit)
+	if err != nil {
+		return fmt.Errorf("could not determine targets: %w", err)
+	}
+
+	for _, f := range files {
+		fmt.Println(f)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"tidbyt.dev/pixlet/cmd"
+	"tidbyt.dev/pixlet/cmd/community"
 )
 
 var (
@@ -29,6 +30,7 @@ func init() {
 	rootCmd.AddCommand(cmd.LintCmd)
 	rootCmd.AddCommand(cmd.CreateCmd)
 	rootCmd.AddCommand(cmd.CheckCmd)
+	rootCmd.AddCommand(community.CommunityCmd)
 }
 
 func main() {


### PR DESCRIPTION
# Overview
Right now, changing or adding a single app in the community repo causes all apps to need to be tested and "built". Ideally, only the apps that have changed would have checks ran against them so that faulty apps don't impact new developers.

This change introduces a subcommand for `community` where we can start putting tooling that normal users don't need to think about. For the first command, this change has added `target-determinator` to be able to determine which app "packages" (directories) have changed. This can then be piped into `pixlet check` to be able to test all apps in a changeset.

# Next Steps
This change does the work of finding changed apps between two commits. It doesn't do any work figuring out what those commits should be. I'm not sure if it should, or if we should use the git cli for that in CI and use those as arguments. 

# Demo
```
$ pixlet community target-determinator --new adf4f71c22d49d39a61cf9aae7a09542aa5cf459 --old faa4e182e1f5277fdf2d6850b324ff2358e43c2c
apps/stripesales/
```

That output can then be used by pixlet check:
```
pixlet check -r apps/stripesales/
✖ apps/stripesales/stripe_sales.star
  ▪️ Problem: app has lint warnings: linting failed with exit code: 4
  ▪️ Solution: try `pixlet lint --fix apps/stripesales/stripe_sales.star`
Error: one or more apps failed checks
```

# Changes
- [community: Create target determinator command.](https://github.com/tidbyt/pixlet/commit/041dbd190cbde58b6b078414871f28f641b56e91) 
    -This commit adds a base target determinator command that is capable of providing the changed files between two commits.
- [community: Update target determinator to use tree diff.](https://github.com/tidbyt/pixlet/commit/2fcd8f2dca9f2ca863b62bb47b2b037b15712d51) 
    - This commit updates the method for finding files to use built-ins for diffing the tree. My original method of going through commits linearly wouldn't work in all cases and would be error prone.
