### PR TITLE
fix: Clean up from manual testing

### DIFF
--- a/cmd/buildifier.go
+++ b/cmd/buildifier.go
@@ -178,6 +178,7 @@ var disabledWarnings = map[string]bool{
 	"native-java":               true, // disables native java rules
 	"native-proto":              true, // disables native proto rules
 	"native-py":                 true, // disables native python rules
+	"module-docstring":          true, // disables module docstring
 	"string-iteration":          true, // disables string iteration warning
 	"unsorted-dict-items":       true, // disables dictionary sorting
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/bazelbuild/buildtools/buildifier/utils"
@@ -35,6 +36,12 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("could not discover apps using recursive flag: %w", err)
 		}
 		apps = discovered
+	} else {
+		for _, app := range apps {
+			if filepath.Ext(app) != ".star" {
+				return fmt.Errorf("only starlark source files or directories with the recursive flag are supported")
+			}
+		}
 	}
 
 	// Check every app.
@@ -104,7 +111,7 @@ func failure(app string, err error, sol string) {
 		// The builtin starlark Backtrace function prints the last line at an
 		// awkward indentation level. This check helps keep the failure indented
 		// at one more level to ensure it's even more clear what is broken.
-		if strings.Contains(line, "Error in") && index == len(multilineError)-1 {
+		if (strings.Contains(line, "Error in") || strings.Contains(line, "Error:")) && index == len(multilineError)-1 {
 			multilineError[index] = fmt.Sprintf("      %s", line)
 		} else {
 			multilineError[index] = fmt.Sprintf("  %s", line)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -59,5 +59,19 @@ func lintCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("linting failed with exit code: %d", exitCode)
 	}
 
+	// Buildifier will return a zero exit status when the fix flag is provided,
+	// even if there are still lint issues that could not be fixed. So we need
+	// to run it twice to get the full picture - once with fix enabled and once
+	// more to determine what else needs to be fixed manually.
+	if fixFlag {
+		mode = "check"
+		lint = "warn"
+
+		exitCode := runBuildifier(args, lint, mode, outputFormat, rflag, vflag)
+		if exitCode != 0 {
+			return fmt.Errorf("linting failed with exit code: %d", exitCode)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
# Changes
- [check: Fix issue with directory and no rflag.](https://github.com/tidbyt/pixlet/commit/f4802062d8b12df8bacbc2cc34be1fb01507167e) 
    - This commit resolves an issues where a directory without a recursive flag would cause non standard errors by adding validation.
- [lint: Run the linter twice with --fix.](https://github.com/tidbyt/pixlet/commit/ada4af4d7a97c4c4e3f6795a8c6df5f7e082046e) 
    - This commit resolves an issue where the --fix flag would cause no output and a zero exit code if there were issues resolved, even if it could not resolve all issues. To get around that, this change runs the linter a second time without fix to ensure the exit is still 0 or print the unresolvable errors.
- [lint: Ignore docstring warning.](https://github.com/tidbyt/pixlet/commit/0e7f993feafeda5e64fcae45ef898f4db9c12ea7) 
    - I wasn't sure if we were going to use the docstrings in the community repo. I've ultimately decided against it and am disabling the linter since it's not necessary.