### PR TITLE
build: Fix Windows build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,12 +47,13 @@ jobs:
         uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
         with:
+          msystem: mingw64
           update: true
           install: >-
             make
+            curl
             mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-libwebp
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -64,6 +65,14 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macos-latest'
         run: ./scripts/setup-macos.sh
+
+      - name: Install Windows dependencies
+        if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
+        run: |
+          set MSYSTEM=MINGW64
+          curl -LO https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libwebp-1.2.4-4-any.pkg.tar.zst
+          pacman -U --noconfirm mingw-w64-x86_64-libwebp-1.2.4-4-any.pkg.tar.zst
 
       - name: Install frontend dependencies
         run: npm install
@@ -77,7 +86,9 @@ jobs:
 
       - name: Build Windows
         shell: msys2 {0}
-        run: make build
+        run: |
+          set MSYSTEM=MINGW64
+          make build
         if: matrix.os == 'windows-latest'
 
       - name: Test
@@ -86,7 +97,9 @@ jobs:
 
       - name: Test Windows
         shell: msys2 {0}
-        run: make test
+        run: |
+          set MSYSTEM=MINGW64
+          make test
         if: matrix.os == 'windows-latest'
 
       - name: Set pixlet version
@@ -95,9 +108,11 @@ jobs:
         if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-latest'
 
       - name: Set Windows pixlet version
-        id: windowsvars 
+        id: windowsvars
         shell: msys2 {0}
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: |
+          set MSYSTEM=MINGW64
+          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
         if: matrix.os == 'windows-latest'
 
       - name: Build Release Linux
@@ -115,7 +130,9 @@ jobs:
       - name: Build Release Windows
         if: matrix.os == 'windows-latest'
         shell: msys2 {0}
-        run: make release-windows
+        run: |
+          set MSYSTEM=MINGW64
+          make release-windows
         env:
           PIXLET_VERSION: ${{ steps.windowsvars.outputs.tag }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,6 +45,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
         with:
+          msystem: mingw64
           update: true
           install: >-
             make
@@ -75,7 +76,9 @@ jobs:
 
       - name: Build Windows
         shell: msys2 {0}
-        run: make build
+        run: |
+          set MSYSTEM=MINGW64
+          make build
         if: matrix.os == 'windows-latest'
 
       - name: Test
@@ -84,5 +87,7 @@ jobs:
 
       - name: Test Windows
         shell: msys2 {0}
-        run: make test
+        run: |
+          set MSYSTEM=MINGW64
+          make test
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,9 +49,9 @@ jobs:
           update: true
           install: >-
             make
+            curl
             mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-libwebp
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -63,6 +63,14 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macos-latest'
         run: brew install webp
+
+      - name: Install Windows dependencies
+        if: matrix.os == 'windows-latest'
+        shell: msys2 {0}
+        run: |
+          set MSYSTEM=MINGW64
+          curl -LO https://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libwebp-1.2.4-4-any.pkg.tar.zst
+          pacman -U --noconfirm mingw-w64-x86_64-libwebp-1.2.4-4-any.pkg.tar.zst
 
       - name: Install frontend dependencies
         run: npm install


### PR DESCRIPTION
This commit resolves the Windows build issue by pinning the libwebp release. The newest release made some changes to the way it's built that doesn't work on MSYS2 environments. There is chatter about folks resolving the issue, but this unblocks us for now.

This change also specifies the MSYS2 "system" we want to use, which is mingw64.