### PR TITLE
Support schema.Location in pixlet serve

### DIFF
--- a/src/features/schema/FieldDetails.jsx
+++ b/src/features/schema/FieldDetails.jsx
@@ -5,6 +5,7 @@ import PhotoSelect from './fields/photoselect/PhotoSelect';
 import Toggle from './fields/Toggle';
 import DateTime from './fields/DateTime';
 import Dropdown from './fields/Dropdown';
+import LocationForm from './fields/location/LocationForm';
 import TextInput from './fields/TextInput';
 import Typeahead from './fields/Typeahead';
 import Typography from '@mui/material/Typography';
@@ -17,7 +18,7 @@ export default function FieldDetails({ field }) {
         case 'dropdown':
             return <Dropdown field={field} />
         case 'location':
-            return <Typography>schema.Location() is not yet supported in pixlet, but is supported in the community repo. Be on the lookout for this field to be available in a future release.</Typography>
+            return <LocationForm field={field} />
         case 'locationbased':
             return <Typography>schema.LocationBased() is not yet supported in pixlet, but is supported in the community repo. Be on the lookout for this field to be available in a future release.</Typography>
         case 'oauth2':

--- a/src/features/schema/fields/location/InputSlider.jsx
+++ b/src/features/schema/fields/location/InputSlider.jsx
@@ -1,0 +1,75 @@
+// https://mui.com/material-ui/react-slider/#InputSlider.js
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import Slider from '@mui/material/Slider';
+import MuiInput from '@mui/material/Input';
+
+const Input = styled(MuiInput)`
+  width: 80px;
+`;
+
+export default function InputSlider({ min, max, step }) {
+  const [value, setValue] = React.useState(0);
+
+  const handleSliderChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  const handleInputChange = (event) => {
+    if (event.target.value === '') {
+      setValue('');
+      return;
+    }
+    const value = Number(event.target.value);
+    if (value < min) {
+      setValue(min);
+    } else if (value > max) {
+      setValue(max);
+    } else {
+      setValue(value);
+    }
+  };
+
+  const handleBlur = () => {
+    if (value < min) {
+      setValue(min);
+    } else if (value > max) {
+      setValue(max);
+    }
+  };
+
+  return (
+    <Box sx={{ width: 250 }}>
+      <Grid container spacing={2} alignItems="center">
+        <Grid item xs>
+          <Slider
+            value={typeof value === 'number' ? value : 0}
+            min={min}
+            max={max}
+            step={step}
+            onChange={handleSliderChange}
+            aria-labelledby="input-slider"
+          />
+        </Grid>
+        <Grid item>
+          <Input
+            value={value}
+            size="small"
+            onChange={handleInputChange}
+            onBlur={handleBlur}
+            inputProps={{
+              step: {step},
+              min: {min},
+              max: {max},
+              type: 'number',
+              'aria-labelledby': 'input-slider',
+            }}
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/features/schema/fields/location/InputSlider.jsx
+++ b/src/features/schema/fields/location/InputSlider.jsx
@@ -1,5 +1,6 @@
-// https://mui.com/material-ui/react-slider/#InputSlider.js
-import * as React from 'react';
+// Largely based on https://mui.com/material-ui/react-slider/#InputSlider.js
+import React, { useState } from 'react';
+
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
@@ -11,16 +12,18 @@ const Input = styled(MuiInput)`
   width: 80px;
 `;
 
-export default function InputSlider({ min, max, step }) {
-  const [value, setValue] = React.useState(0);
+export default function InputSlider({ min, max, step, defaultValue, onChange}) {
+  const [value, setValue] = useState(defaultValue);
 
   const handleSliderChange = (event, newValue) => {
     setValue(newValue);
+    onChange(event);
   };
 
   const handleInputChange = (event) => {
     if (event.target.value === '') {
       setValue('');
+      onChange(event);
       return;
     }
     const value = Number(event.target.value);
@@ -31,6 +34,7 @@ export default function InputSlider({ min, max, step }) {
     } else {
       setValue(value);
     }
+    onChange(event);
   };
 
   const handleBlur = () => {
@@ -46,7 +50,7 @@ export default function InputSlider({ min, max, step }) {
       <Grid container spacing={2} alignItems="center">
         <Grid item xs>
           <Slider
-            value={typeof value === 'number' ? value : 0}
+            value={value}
             min={min}
             max={max}
             step={step}

--- a/src/features/schema/fields/location/LocationForm.jsx
+++ b/src/features/schema/fields/location/LocationForm.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import InputSlider from './InputSlider';
+import { set } from '../../../config/configSlice';
+
+export default function LocationForm({ field }) {
+    const [value, setValue] = useState(field.default);
+    const config = useSelector(state => state.config);
+
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        // if (field.id in config) {
+        //     setValue(config[field.id].value);
+        // } else if (field.default) {
+        //     dispatch(set({
+        //         id: field.id,
+        //         value: field.default,
+        //     }));
+        // }
+    }, [])
+
+    const onChange = (event) => {
+        console.log(field);
+        // setValue(event.target.value);
+        // dispatch(set({
+        //     id: field.id,
+        //     value: event.target.value,
+        // }));
+    }
+
+    return (
+        <FormControl fullWidth>
+            <Typography>Latitude</Typography>
+            <InputSlider
+            	min={-90}
+            	max={90}
+            	step={0.1}
+            >
+            </InputSlider>
+            <Typography>Longitude</Typography>
+            <InputSlider
+            	min={-180}
+            	max={180}
+            	step={0.1}
+            >
+            </InputSlider>
+            <Typography>Locality</Typography>
+            <TextField
+            	fullWidth
+            	defaultValue="Somewhere"
+            	variant="outlined"
+            	// onChange={onChange}
+            	style={{ marginBottom: '0.5rem' }} 
+            />
+            <Typography>Timezone</Typography>
+            <Select
+                // onChange={onChange}
+            >
+                {Intl.supportedValuesOf('timeZone').map((zone) => {
+                    return <MenuItem value={zone}>{zone}</MenuItem>
+                })}
+            </Select>
+        </FormControl>
+    );
+}

--- a/src/features/schema/fields/location/LocationForm.jsx
+++ b/src/features/schema/fields/location/LocationForm.jsx
@@ -12,29 +12,57 @@ import InputSlider from './InputSlider';
 import { set } from '../../../config/configSlice';
 
 export default function LocationForm({ field }) {
-    const [value, setValue] = useState(field.default);
+    const [value, setValue] = useState({
+    	// Default to Brooklyn, because that's where tidbyt folks
+    	// are and  we can only dispatch a location object which
+    	// has all fields set.
+    	'lat': 40.6782,
+    	'lng': -73.9442,
+    	'locality': 'Brooklyn, New York',
+    	'timezone': 'America/New_York',
+    	// But overwrite with app-specific defaults set in config.
+    	...field.default
+   	});
+
     const config = useSelector(state => state.config);
 
     const dispatch = useDispatch();
 
     useEffect(() => {
-        // if (field.id in config) {
-        //     setValue(config[field.id].value);
-        // } else if (field.default) {
-        //     dispatch(set({
-        //         id: field.id,
-        //         value: field.default,
-        //     }));
-        // }
+        if (field.id in config) {
+            setValue(JSON.parse(config[field.id].value));
+        } else if (field.default) {
+            dispatch(set({
+                id: field.id,
+                value: field.default,
+            }));
+        }
     }, [])
 
-    const onChange = (event) => {
-        console.log(field);
-        // setValue(event.target.value);
-        // dispatch(set({
-        //     id: field.id,
-        //     value: event.target.value,
-        // }));
+    const setPart = (partName, partValue) => {
+    	let newValue = {...value};
+    	newValue[partName] = partValue;
+    	setValue(newValue);
+    	dispatch(set({
+    		id: field.id,
+    		value: JSON.stringify(newValue),
+    	}));
+    }
+
+    const onChangeLatitude = (event) => {
+        setPart('lat', event.target.value);
+    }
+
+    const onChangeLongitude = (event) => {
+    	setPart('lng', event.target.value);
+    }
+
+    const onChangeLocality = (event) => {
+    	setPart('locality', event.target.value);
+    }
+
+    const onChangeTimezone = (event) => {
+    	setPart('timezone', event.target.value);
     }
 
     return (
@@ -44,6 +72,8 @@ export default function LocationForm({ field }) {
             	min={-90}
             	max={90}
             	step={0.1}
+            	onChange={onChangeLatitude}
+            	defaultValue={value['lat']}
             >
             </InputSlider>
             <Typography>Longitude</Typography>
@@ -51,19 +81,22 @@ export default function LocationForm({ field }) {
             	min={-180}
             	max={180}
             	step={0.1}
+            	onChange={onChangeLongitude}
+            	defaultValue={value['lng']}
             >
             </InputSlider>
             <Typography>Locality</Typography>
             <TextField
             	fullWidth
-            	defaultValue="Somewhere"
             	variant="outlined"
-            	// onChange={onChange}
+            	onChange={onChangeLocality}
             	style={{ marginBottom: '0.5rem' }} 
+            	defaultValue={value['locality']}
             />
             <Typography>Timezone</Typography>
             <Select
-                // onChange={onChange}
+                onChange={onChangeTimezone}
+                defaultValue={value['timezone']}
             >
                 {Intl.supportedValuesOf('timeZone').map((zone) => {
                     return <MenuItem value={zone}>{zone}</MenuItem>


### PR DESCRIPTION
One of the biggest frustrations as an app developer is not being able to test the effect of setting Location and LocationBased fields. We can't set them in pixlet serve (or the iPhone app until published), and it's hard to know if we've done the right job of decoding the output, as it gets transformed before we see it.

This PR adds support for Location fields. It is quite simplistic and all four fields in the location object are independent. That can lead to nonsense locations, like the latitude and longitude of London, timezone of Tokyo and name of New York. But there doesn't seem to be any free geolocation service to let you work out the timezone/name for a given latitude and longitude. It still seems a big step forward for developers to be able to do this at all.

The sunrisesunset app is a particularly good one to try it with, since it uses the latitude, longitude and timezone fields. Most apps seem to just care about the timezone.

There's a few things you should probably pay particular attention to:
 - This is the first React I've ever written, so please don't assume I know what I'm doing.
 - I don't know what useEffect is, I just copied from another file.
 - The way I passed an onChange callback as a parameter into InputSlider.
 - Hardcoding "America/New_York" as a default timezone, in case it won't work for Windows users.
 - In LocationForm, creating a copy of the value object on change, rather than updating the existing value object.
 - Whether you think it looks the part.

After taking on board feedback about this PR, I might try looking at supporting LocationBased because that would be an enormous win for us app developers.

[Screenshot](https://cdn.discordapp.com/attachments/928638975298650172/1066063148072841316/Screenshot_2023-01-20_at_18.33.55.png) -- it seems to play nicely with other config fields too.