### PR TITLE
Support schema.LocationBased in pixlet serve

### DIFF
--- a/src/features/schema/FieldDetails.jsx
+++ b/src/features/schema/FieldDetails.jsx
@@ -5,6 +5,7 @@ import PhotoSelect from './fields/photoselect/PhotoSelect';
 import Toggle from './fields/Toggle';
 import DateTime from './fields/DateTime';
 import Dropdown from './fields/Dropdown';
+import LocationBased from './fields/location/LocationBased';
 import LocationForm from './fields/location/LocationForm';
 import TextInput from './fields/TextInput';
 import Typeahead from './fields/Typeahead';
@@ -20,7 +21,7 @@ export default function FieldDetails({ field }) {
         case 'location':
             return <LocationForm field={field} />
         case 'locationbased':
-            return <Typography>schema.LocationBased() is not yet supported in pixlet, but is supported in the community repo. Be on the lookout for this field to be available in a future release.</Typography>
+            return <LocationBased field={field} />
         case 'oauth2':
             return <OAuth2 field={field} />
         case 'png':

--- a/src/features/schema/fields/location/LocationBased.jsx
+++ b/src/features/schema/fields/location/LocationBased.jsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import InputSlider from './InputSlider';
+import { set } from '../../../config/configSlice';
+import { callHandler } from '../../../handlers/actions';
+
+export default function LocationBased({ field }) {
+    const [locationValue, setLocationValue] = useState({
+    	// Default to Brooklyn, because that's where tidbyt folks
+    	// are and  we can only dispatch a location object which
+    	// has all fields set.
+    	'lat': 40.6782,
+    	'lng': -73.9442,
+    	'locality': 'Brooklyn, New York',
+    	'timezone': 'America/New_York'
+   	});
+
+    const [value, setValue] = useState(field.default);
+
+    const config = useSelector(state => state.config);
+    const dispatch = useDispatch();
+    const handlerResults = useSelector(state => state.handlers)
+
+    useEffect(() => {
+        if (field.id in config) {
+            setValue(config[field.id].value);
+        } else if (field.default) {
+            dispatch(set({
+                id: field.id,
+                value: field.default,
+            }));
+        }
+        callHandler(field.id, field.handler, JSON.stringify(locationValue));
+    }, [])
+
+    const setPart = (partName, partValue) => {
+    	let newLocationValue = {...locationValue};
+    	newLocationValue[partName] = partValue;
+    	setLocationValue(newLocationValue);
+        callHandler(field.id, field.handler, JSON.stringify(newLocationValue));
+    }
+
+    const onChangeLatitude = (event) => {
+        setPart('lat', event.target.value);
+    }
+
+    const onChangeLongitude = (event) => {
+    	setPart('lng', event.target.value);
+    }
+
+    const onChangeLocality = (event) => {
+    	setPart('locality', event.target.value);
+    }
+
+    const onChangeTimezone = (event) => {
+    	setPart('timezone', event.target.value);
+    }
+
+    const onChangeOption = (event) => {
+        setValue(event.target.value);
+        dispatch(set({
+            id: field.id,
+            value: JSON.stringify({'value': event.target.value})
+        }));
+    }
+
+    let options = [];
+    if (field.id in handlerResults.values) {
+        options = handlerResults.values[field.id];
+    }
+
+    return (
+        <FormControl fullWidth>
+            <Typography>Latitude</Typography>
+            <InputSlider
+            	min={-90}
+            	max={90}
+            	step={0.1}
+            	onChange={onChangeLatitude}
+            	defaultValue={locationValue['lat']}
+            >
+            </InputSlider>
+            <Typography>Longitude</Typography>
+            <InputSlider
+            	min={-180}
+            	max={180}
+            	step={0.1}
+            	onChange={onChangeLongitude}
+            	defaultValue={locationValue['lng']}
+            >
+            </InputSlider>
+            <Typography>Locality</Typography>
+            <TextField
+            	fullWidth
+            	variant="outlined"
+            	onChange={onChangeLocality}
+            	style={{ marginBottom: '0.5rem' }} 
+            	defaultValue={locationValue['locality']}
+            />
+            <Typography>Timezone</Typography>
+            <Select
+                onChange={onChangeTimezone}
+                style={{ marginBottom: '0.5rem' }} 
+                defaultValue={locationValue['timezone']}
+            >
+                {Intl.supportedValuesOf('timeZone').map((zone) => {
+                    return <MenuItem value={zone}>{zone}</MenuItem>
+                })}
+            </Select>
+            <Typography>Options for chosen location</Typography>
+            <Select
+                onChange={onChangeOption}
+            >
+                {options.map((option) => {
+                    return <MenuItem key={option.value} value={option.value}>{option.display}</MenuItem>
+                })}
+            </Select>
+        </FormControl>
+    );
+}


### PR DESCRIPTION
An extra step to https://github.com/tidbyt/pixlet/pull/585 but more important. (Only the last commit is new here. I just don't know how to make a stack of changelists across repos in GitHub)

This adds a LocationBased widget that is very similar to LocationForm. However, when the location is set, it calls the relevant handler to get a list of options, and then displays them in a dropdown menu.

The chosen option is added to the URL and persisted on page reload. However, the location isn't. It could be done by adding the location to the widget's value object, but I don't want to introduce something that isn't supported in production. As far as I know, only the selected option value should be available to the starlark script.

I wonder if it's possible to add a button to dismiss snackbars. I often got a permanent red box because the handler didn't like receiving a '55.' because it doesn't parse as an int, but I was mid-typing!