### PR TITLE
Use Zig CC for CGO in Linux releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           node-version: "16"
 
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        if: matrix.os == 'ubuntu-22.04'
+
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
@@ -119,6 +123,7 @@ jobs:
         if: matrix.os == 'ubuntu-22.04'
         run: make release-linux
         env:
+          GLIBC_VERSION: "2.25"
           PIXLET_VERSION: ${{ steps.vars.outputs.tag }}
 
       - name: Build Release macOS

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -10,6 +10,11 @@ if [ -z "$RELEASE_PLATFORM" ]; then
 	exit 1
 fi
 
+if [[ $RELEASE_PLATFORM == "linux" && -z "$GLIBC_VERSION" ]]; then
+	echo "Please set GLIBC_VERSION"
+	exit 1
+fi
+
 for ARCH in $RELEASE_ARCHS
 do
 	if [[ $ARCH == *arm*  ]]; then
@@ -22,10 +27,10 @@ do
 
 	if [[ $ARCH == "linux-arm64"  ]]; then
 		echo "linux-arm64"
-		 CC=aarch64-linux-gnu-gcc CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+		CC="zig cc -target aarch64-linux-gnu.${GLIBC_VERSION} -isystem /usr/include -L/usr/lib/aarch64-linux-gnu" CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "linux-amd64"  ]]; then
 		echo "linux-amd64"
-		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
+		CC="zig cc -target x86_64-linux-gnu.${GLIBC_VERSION} -isystem /usr/include -L/usr/lib/x86_64-linux-gnu" CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -Wl,-Bdynamic" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "windows-amd64"  ]]; then
 		echo "windows-amd64"
 		go build -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet


### PR DESCRIPTION
This allows us to specify the version of glibc that the binary is linked against (see https://github.com/tidbyt/pixlet/issues/521#issuecomment-1378033904). I have selected version 2.25 as that should cover most commonly-used distros (see https://github.com/tidbyt/pixlet/issues/521#issuecomment-1366228055), but this can be adjusted if support for even older releases is desired. A value of 2.17 would cover approximately every currently-maintained major release, but I don't know that we care about RHEL/CentOS 7 or Slackware 14.

Fixes: #521