### PR TITLE
feat: Add spell checking support

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -112,6 +112,22 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
+		// Check spelling in both the app and the manifest.
+		community.SilentSpelling = true
+		err = community.SpellCheck(cmd, []string{app})
+		if err != nil {
+			foundIssue = true
+			failure(app, fmt.Errorf("app contains spelling errors: %w", err), fmt.Sprintf("try `pixlet community spell-check --fix %s`", app))
+			continue
+		}
+		err = community.SpellCheck(cmd, []string{manifestFile})
+		if err != nil {
+			foundIssue = true
+			failure(app, fmt.Errorf("manifest contains spelling errors: %w", err), fmt.Sprintf("try `pixlet community spell-check --fix %s`", manifestFile))
+			continue
+		}
+
+		// If we're here, the app and manifest are good to go!
 		success(app)
 	}
 

--- a/cmd/community/community.go
+++ b/cmd/community/community.go
@@ -7,6 +7,7 @@ import (
 func init() {
 	CommunityCmd.AddCommand(CreateManifestCmd)
 	CommunityCmd.AddCommand(ListIconsCmd)
+	CommunityCmd.AddCommand(SpellCheckCmd)
 	CommunityCmd.AddCommand(TargetDeterminatorCmd)
 	CommunityCmd.AddCommand(ValidateIconsCmd)
 	CommunityCmd.AddCommand(ValidateManifestCmd)

--- a/cmd/community/spellcheck.go
+++ b/cmd/community/spellcheck.go
@@ -1,0 +1,87 @@
+package community
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/client9/misspell"
+	"github.com/spf13/cobra"
+)
+
+var (
+	FixSpelling    bool
+	SilentSpelling bool
+)
+
+func init() {
+	SpellCheckCmd.Flags().BoolVarP(&FixSpelling, "fix", "f", false, "fixes spelling mistakes automatically")
+	SpellCheckCmd.Flags().BoolVarP(&SilentSpelling, "silent", "s", false, "silences spelling mistakes")
+}
+
+var SpellCheckCmd = &cobra.Command{
+	Use:   "spell-check <filespec>",
+	Short: "Spell check for a file",
+	Example: `  pixlet community spell-check manifest.yaml
+  pixlet community spell-check app.star`,
+	Long: `This command checks the spelling of strings located in a file. This can be used
+both for a manifest and Tidbyt app.`,
+	Args: cobra.ExactArgs(1),
+	RunE: SpellCheck,
+}
+
+func SpellCheck(cmd *cobra.Command, args []string) error {
+	// Load file for checking.
+	f, err := os.OpenFile(args[0], os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("could not open file: %w", err)
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("could not read file: %w", err)
+	}
+
+	// Create replacer.
+	r := misspell.Replacer{
+		Replacements: misspell.DictMain,
+	}
+
+	// Tidbyt is primarily in US markets. We only ship a US power plug, and all
+	// materials are in the US locale. In the future, we will need to consider
+	// how we manage spell check as we look to support more markets.
+	r.AddRuleList(misspell.DictAmerican)
+	r.Compile()
+
+	// Run replacer.
+	updated, diffs := r.Replace(string(b))
+
+	// If FixSpelling is true, we only want to fix spelling and return
+	if FixSpelling {
+		_, err := f.Seek(0, io.SeekStart)
+		if err != nil {
+			return fmt.Errorf("could not update file: %w", err)
+		}
+
+		_, err = f.WriteString(updated)
+		if err != nil {
+			return fmt.Errorf("could not update file: %w", err)
+		}
+
+		return nil
+	}
+
+	if !SilentSpelling {
+		for _, diff := range diffs {
+			fmt.Printf("`%s` is a misspelling of `%s` at line: %d\n", diff.Original, diff.Corrected, diff.Line)
+		}
+	}
+
+	// Return error if there are any diffs.
+	if len(diffs) > 0 {
+		return fmt.Errorf("%s contains spelling errors", args[0])
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 
 require (
 	github.com/chzyer/readline v1.5.0 // indirect
+	github.com/client9/misspell v0.3.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/chzyer/readline v1.5.0 h1:lSwwFrbNviGePhkewF1az4oLmcwqCZijQ2/Wi3BGHAI
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0 h1:bZgT/A+cikZnKIwn7xL2OBj012Bmvho/o6RpRvv3GKY=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=


### PR DESCRIPTION
# Overview
This change adds a native spell checker to pixlet. This is the last step to converting all of our existing toolchain to be native in pixlet.

# Demo
```
$ pixlet community spell-check foo.star
`colour` is a misspelling of `color` at line: 11
Error: foo.star contains spelling errors
```
```
$ pixlet check foo.star
✖ foo.star
  ▪️ Problem: app contains spelling errors: foo.star contains spelling errors
  ▪️ Solution: try `pixlet community spell-check --fix foo.star`
Error: one or more apps failed checks
```
```
$ pixlet community spell-check foo.star --fix
$ pixlet check foo.star
✔️ foo.star
```

# Changes
- [community: Add a spell check command.](https://github.com/tidbyt/pixlet/commit/0d54457e301baa276d996206478b68650ecad7e1) 
    - This commit adds a spell check command that is capable of checking a file for spelling mistakes and fixing them.
- [check: Add spell checking to manifest and app.](https://github.com/tidbyt/pixlet/commit/aa161df2c868034514ec18b9677e202241aacf5e) 
    - This commit adds spell checking support to the manifest and the app files.