### PR TITLE
fix: Community Integration Bugs

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -46,6 +46,8 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// TODO: this needs to be parallelized.
+
 	// Check every app.
 	foundIssue := false
 	for _, app := range apps {
@@ -65,13 +67,14 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 		}
 		defer os.Remove(f.Name())
 
-		// Check if app will render.
-		silenceOutput = true
-		output = f.Name()
-		err = render(cmd, []string{app})
+		// TODO: Check if app will render once we are able to enable target
+		// determination.
+
+		// Check if an app can load.
+		err = community.LoadApp(cmd, []string{app})
 		if err != nil {
 			foundIssue = true
-			failure(app, fmt.Errorf("app failed to render: %w", err), fmt.Sprintf("try `pixlet render %s` and resolve any errors", app))
+			failure(app, fmt.Errorf("app failed to load: %w", err), "try `pixlet community load-app` and resolve any runtime issues")
 			continue
 		}
 
@@ -109,20 +112,16 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Check spelling in both the app and the manifest.
+		// Check spelling.
 		community.SilentSpelling = true
-		err = community.SpellCheck(cmd, []string{app})
-		if err != nil {
-			foundIssue = true
-			failure(app, fmt.Errorf("app contains spelling errors: %w", err), fmt.Sprintf("try `pixlet community spell-check --fix %s`", app))
-			continue
-		}
 		err = community.SpellCheck(cmd, []string{manifestFile})
 		if err != nil {
 			foundIssue = true
 			failure(app, fmt.Errorf("manifest contains spelling errors: %w", err), fmt.Sprintf("try `pixlet community spell-check --fix %s`", manifestFile))
 			continue
 		}
+		// TODO: enable spell check for apps once we can run it successfully
+		// against the community repo.
 
 		// If we're here, the app and manifest are good to go!
 		success(app)

--- a/cmd/community/community.go
+++ b/cmd/community/community.go
@@ -7,6 +7,7 @@ import (
 func init() {
 	CommunityCmd.AddCommand(CreateManifestCmd)
 	CommunityCmd.AddCommand(ListIconsCmd)
+	CommunityCmd.AddCommand(LoadAppCmd)
 	CommunityCmd.AddCommand(SpellCheckCmd)
 	CommunityCmd.AddCommand(TargetDeterminatorCmd)
 	CommunityCmd.AddCommand(ValidateIconsCmd)

--- a/cmd/community/createmanifest.go
+++ b/cmd/community/createmanifest.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"tidbyt.dev/pixlet/manifest"
 )
 
 var CreateManifestCmd = &cobra.Command{
@@ -19,8 +20,8 @@ var CreateManifestCmd = &cobra.Command{
 
 func CreateManifest(cmd *cobra.Command, args []string) error {
 	fileName := filepath.Base(args[0])
-	if fileName != "manifest.yaml" && fileName != "manifest.yml" {
-		return fmt.Errorf("supplied manifest must be named manifest.yaml or manifest.yml")
+	if fileName != manifest.ManifestFileName {
+		return fmt.Errorf("supplied manifest must be named %s", manifest.ManifestFileName)
 	}
 
 	f, err := os.Create(args[0])

--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -1,0 +1,41 @@
+package community
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var LoadAppCmd = &cobra.Command{
+	Use:     "load-app <filespec>",
+	Short:   "Validates an app can be successfully loaded in our runtime.",
+	Example: `  pixlet community load-app app.star`,
+	Long:    `This command ensures an app can be loaded into our runtime successfully.`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    LoadApp,
+}
+
+func LoadApp(cmd *cobra.Command, args []string) error {
+	script := args[0]
+
+	if !strings.HasSuffix(script, ".star") {
+		return fmt.Errorf("script file must have suffix .star: %s", script)
+	}
+
+	src, err := ioutil.ReadFile(script)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", script, err)
+	}
+	runtime.InitCache(runtime.NewInMemoryCache())
+
+	applet := runtime.Applet{}
+	err = applet.Load(script, src, nil)
+	if err != nil {
+		return fmt.Errorf("failed to load applet: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/community/validatemanifest.go
+++ b/cmd/community/validatemanifest.go
@@ -21,8 +21,8 @@ validating the contents of each field.`,
 
 func ValidateManifest(cmd *cobra.Command, args []string) error {
 	fileName := filepath.Base(args[0])
-	if fileName != "manifest.yaml" && fileName != "manifest.yml" {
-		return fmt.Errorf("supplied manifest must be named manifest.yaml or manifest.yml")
+	if fileName != manifest.ManifestFileName {
+		return fmt.Errorf("supplied manifest must be named %s", manifest.ManifestFileName)
 	}
 
 	f, err := os.Open(args[0])

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const ManifestFileName = "manifest.yaml"
+
 // Manifest is a structure to define a starlark applet for Tidbyt in Go.
 type Manifest struct {
 	// ID is the unique identifier of this app. It has to be globally unique,

--- a/tools/generator/generator.go
+++ b/tools/generator/generator.go
@@ -98,7 +98,7 @@ func (g *Generator) writeManifest(app *manifest.Manifest) error {
 	var p string
 	switch g.appType {
 	case Community:
-		p = path.Join(g.root, appsDir, app.PackageName, app.FileName)
+		p = path.Join(g.root, appsDir, app.PackageName, manifestName)
 	default:
 		p = path.Join(g.root, manifestName)
 	}


### PR DESCRIPTION
# Overview
This change set fixes a few bugs I encountered while integrating with the community repo.

# Changes
- [fix: Resolve an issue with manifest file names.](https://github.com/tidbyt/pixlet/commit/24be2001b9fa429af2ec0f93975594e1f94286b6) 
    - This commit resolves an issue where the manifest file was not being written to the correct location and was overwriting the starlark source, but only in the community repo.
- [fix: Make the manifest filename a constant.](https://github.com/tidbyt/pixlet/commit/c06d4e344b5b700d6425821699585c5ffd8d3286) 
    - This commit removes the ability to have a .yml ending switches all uses to be a constant. This will significantly reduce headaches down the line given there is only one file name.
- [community: Add load app command.](https://github.com/tidbyt/pixlet/commit/f71336f0c5887870a480d570cb5494824ea5288b) 
    - This commit adds a load app command so that we can ensure that an app can load, even if it cannot render.
- [fix: Update checks to match community.](https://github.com/tidbyt/pixlet/commit/c296bf1c9bbad38dd45dc679b652c61592bd4350) 
    - This commit makes some of the checks a bit less aggressive with a TODO on how to make it more agressive in the future. The reason being, I'd like to get this enabled today as a drop in replacement rather then be more strict.