### PR TITLE
community: Add check for filename matching.

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -105,6 +105,7 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 
 		// Validate manifest.
 		manifestFile := filepath.Join(dir, manifest.ManifestFileName)
+		community.ValidateManifestAppFileName = filepath.Base(app)
 		err = community.ValidateManifest(cmd, []string{manifestFile})
 		if err != nil {
 			foundIssue = true

--- a/cmd/community/validatemanifest.go
+++ b/cmd/community/validatemanifest.go
@@ -9,6 +9,12 @@ import (
 	"tidbyt.dev/pixlet/manifest"
 )
 
+var ValidateManifestAppFileName string
+
+func init() {
+	ValidateManifestCmd.Flags().StringVarP(&ValidateManifestAppFileName, "app-file-name", "a", "", "ensures the app file name is the same as the manifest")
+}
+
 var ValidateManifestCmd = &cobra.Command{
 	Use:     "validate-manifest <pathspec>",
 	Short:   "Validates an app manifest is ready for publishing",
@@ -39,6 +45,10 @@ func ValidateManifest(cmd *cobra.Command, args []string) error {
 	err = m.Validate()
 	if err != nil {
 		return fmt.Errorf("couldn't validate manifest: %w", err)
+	}
+
+	if ValidateManifestAppFileName != "" && m.FileName != ValidateManifestAppFileName {
+		return fmt.Errorf("app name doesn't match: %s != %s", ValidateManifestAppFileName, m.FileName)
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds a validation step that the app we're valdiating matches the fileName property in the manfiest. We've seen a few apps that have a manifest and valid app, but the file names don't match and the build is hard to reason about.