### PR TITLE
Embed timezone database in pixlet

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata"
 
 	"github.com/spf13/cobra"
 	"tidbyt.dev/pixlet/cmd"

--- a/runtime/applet_test.go
+++ b/runtime/applet_test.go
@@ -262,4 +262,21 @@ def main():
 	assert.Equal(t, "foobar", printedText)
 }
 
+func TestTimezoneDatabase(t *testing.T) {
+	src:= `
+load("render.star", "render")
+load("time.star", "time")
+def main():
+     # Fails if America/Los_Angeles is an unknown system.
+ 	t = time.time(hour = 21, minute = 47, location = "America/Los_Angeles")
+ 	return render.Root(child=render.Box())
+`
+
+	app := &Applet{}
+	err := app.Load("test.star", []byte(src), nil)
+	assert.NoError(t, err)
+	_, err = app.Run(map[string]string{})
+	assert.NoError(t, err)
+ }
+
 // TODO: test Screens, especially Screens.Render()


### PR DESCRIPTION
I think this will fix https://github.com/tidbyt/pixlet/issues/551

Importing this into the binary's main embeds a copy of the timezone database. That should put an end to Windows users having to do extra steps to work with most of the community apps. Cost is a slightly larger binary.

https://pkg.go.dev/time/tzdata

Seems OK to me, but I don't have a Windows machine to test it on.

Alternatively, it might be possible to do this just for Windows. See https://github.com/tidbyt/pixlet/pull/616 as an alternative to this PR.