### PR TITLE
Embed timezone database in Windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,17 @@ GIT_COMMIT = $(shell git rev-list -1 HEAD)
 ifeq ($(OS),Windows_NT)
 	BINARY = pixlet.exe
 	LDFLAGS = -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=$(GIT_COMMIT)'"
+	TAGS = -tags timetzdata
 else
 	BINARY = pixlet
 	LDFLAGS = -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=$(GIT_COMMIT)'"
+	TAGS =
 endif
 
 all: build
 
 test:
-	go test -v -cover ./...
+	go test $(TAGS) -v -cover ./...
 
 clean:
 	rm -f $(BINARY)
@@ -22,7 +24,7 @@ bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
 
 build:
-	 go build $(LDFLAGS) -o $(BINARY) tidbyt.dev/pixlet
+	 go build $(LDFLAGS) $(TAGS) -o $(BINARY) tidbyt.dev/pixlet
 
 embedfonts:
 	go run render/gen/embedfonts.go

--- a/runtime/applet_test.go
+++ b/runtime/applet_test.go
@@ -262,4 +262,21 @@ def main():
 	assert.Equal(t, "foobar", printedText)
 }
 
+func TestTimezoneDatabase(t *testing.T) {
+	src:= `
+load("render.star", "render")
+load("time.star", "time")
+def main():
+    # Fails if America/Los_Angeles is an unknown system.
+	t = time.time(hour = 21, minute = 47, location = "America/Los_Angeles")
+	return render.Root(child=render.Box())
+`
+
+	app := &Applet{}
+	err := app.Load("test.star", []byte(src), nil)
+	assert.NoError(t, err)
+	_, err = app.Run(map[string]string{})
+	assert.NoError(t, err)
+}
+
 // TODO: test Screens, especially Screens.Render()

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -28,7 +28,7 @@ do
 		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet
 	elif [[ $ARCH == "windows-amd64"  ]]; then
 		echo "windows-amd64"
-		go build -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
+		go build -ldflags="-s -extldflags=-static -X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -tags timetzdata -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet.exe tidbyt.dev/pixlet
 	else
 		echo "other"
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-X 'tidbyt.dev/pixlet/cmd.Version=${PIXLET_VERSION}'" -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/pixlet tidbyt.dev/pixlet


### PR DESCRIPTION
I think this will fix #551. Alternative to https://github.com/tidbyt/pixlet/pull/615

Windows users keep running into problems because their system doesn't have the timezone database installed. Other platforms have it.

Per https://pkg.go.dev/time/tzdata, building with this flag will embed a copy of the database into the binary, so that the lookup just works out of the box and devs don't have to do any extra steps with zoneinfo.zip.

I don't have a windows machine to try it out, but I added a test that should fail on Windows if the database is not present.