### PR TITLE
encode: use maxDuration==0 instead of MaxInt

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"image"
 	"io/ioutil"
-	"math"
 	"os"
 	"strings"
 
@@ -159,8 +158,8 @@ func render(cmd *cobra.Command, args []string) error {
 
 	var buf []byte
 
-	if screens.ShowFullAnimation || maxDuration == 0 {
-		maxDuration = math.MaxInt
+	if screens.ShowFullAnimation {
+		maxDuration = 0
 	}
 
 	if renderGif {

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -119,16 +119,19 @@ func (s *Screens) EncodeWebP(maxDuration int, filters ...ImageFilter) ([]byte, e
 	remainingDuration := time.Duration(maxDuration) * time.Millisecond
 	for _, im := range images {
 		frameDuration := time.Duration(s.delay) * time.Millisecond
-		if frameDuration > remainingDuration {
-			frameDuration = remainingDuration
+
+		if maxDuration > 0 {
+			if frameDuration > remainingDuration {
+				frameDuration = remainingDuration
+			}
+			remainingDuration -= frameDuration
 		}
-		remainingDuration -= frameDuration
 
 		if err := anim.AddFrame(im, frameDuration); err != nil {
 			return nil, errors.Wrap(err, "adding frame")
 		}
 
-		if remainingDuration <= 0 {
+		if maxDuration > 0 && remainingDuration <= 0 {
 			break
 		}
 	}
@@ -167,15 +170,17 @@ func (s *Screens) EncodeGIF(maxDuration int, filters ...ImageFilter) ([]byte, er
 		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{0, 0}, draw.Src)
 
 		frameDelay := int(s.delay)
-		if frameDelay > remainingDuration {
-			frameDelay = remainingDuration
+		if maxDuration > 0 {
+			if frameDelay > remainingDuration {
+				frameDelay = remainingDuration
+			}
+			remainingDuration -= frameDelay
 		}
-		remainingDuration -= frameDelay
 
 		g.Image = append(g.Image, imPaletted)
 		g.Delay = append(g.Delay, frameDelay/10) // in 100ths of a second
 
-		if remainingDuration <= 0 {
+		if maxDuration > 0 && remainingDuration <= 0 {
 			break
 		}
 	}

--- a/encode/encode_test.go
+++ b/encode/encode_test.go
@@ -349,4 +349,15 @@ def main():
 	for _, d := range gifDelays(gifData) {
 		assert.Equal(t, 500, d)
 	}
+
+	// inf ms -> all 100 frames, 500 ms each.
+	gifData, err = ScreensFromRoots(roots).EncodeGIF(0)
+	assert.NoError(t, err)
+	webpData, err = ScreensFromRoots(roots).EncodeWebP(0)
+	assert.NoError(t, err)
+	assert.Equal(t, gifDelays(gifData), webpDelays(webpData))
+	for _, d := range gifDelays(gifData) {
+		assert.Equal(t, 500, d)
+	}
+
 }


### PR DESCRIPTION
Fixes integer overflow when converting to Duration.