### PR TITLE
runtime: Add HMAC module

### DIFF
--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -24,6 +24,7 @@ import (
 
 	"tidbyt.dev/pixlet/render"
 	"tidbyt.dev/pixlet/runtime/modules/animation_runtime"
+	"tidbyt.dev/pixlet/runtime/modules/hmac"
 	"tidbyt.dev/pixlet/runtime/modules/humanize"
 	"tidbyt.dev/pixlet/runtime/modules/qrcode"
 	"tidbyt.dev/pixlet/runtime/modules/random"
@@ -329,6 +330,9 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 	case "hash.star":
 		return starlibhash.LoadModule()
 
+	case "hmac.star":
+		return hmac.LoadModule()
+	
 	case "http.star":
 		return starlibhttp.LoadModule()
 

--- a/runtime/modules/hmac/hmac.go
+++ b/runtime/modules/hmac/hmac.go
@@ -1,0 +1,65 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"sync"
+	"time"
+	
+	godfe "github.com/newm4n/go-dfe"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+
+const (
+	ModuleName = "hmac"
+)
+
+var (
+	once        sync.Once
+	module      starlark.StringDict
+	empty       time.Time
+	translation *godfe.PatternTranslation
+)
+
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		translation = godfe.NewPatternTranslation()
+		module = starlark.StringDict{
+			ModuleName: &starlarkstruct.Module{
+				Name: ModuleName,
+				Members: starlark.StringDict{
+					"md5":    starlark.NewBuiltin("md5", fnHmac(md5.New)),
+					"sha1":   starlark.NewBuiltin("sha1", fnHmac(sha1.New)),
+					"sha256": starlark.NewBuiltin("sha256", fnHmac(sha256.New)),
+				},
+			},
+		}
+	})
+
+	return module, nil
+}
+
+func fnHmac(hashFunc func() hash.Hash) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var (
+			key starlark.String
+			s 	starlark.String
+		)
+		if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &key, &s); err != nil {
+			return nil, err
+		}
+
+		h :=  hmac.New(hashFunc, []byte(string(key)))
+
+		if _, err := h.Write([]byte(string(s))); err != nil {
+			return starlark.None, err
+		}
+		return starlark.String(fmt.Sprintf("%x", h.Sum(nil))), nil
+	}
+}

--- a/runtime/modules/hmac/hmac_test.go
+++ b/runtime/modules/hmac/hmac_test.go
@@ -1,0 +1,35 @@
+package hmac_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/pixlet/runtime"
+)
+
+var hmacSource = `
+load("hmac.star", "hmac")
+
+def assert(success, message=None):
+    if not success:
+        fail(message or "assertion failed")
+
+# Assert.
+
+assert(hmac.md5("secret", "helloworld") == "8bd4df4530c3c2cafabf6986740e44bd")
+assert(hmac.sha1("secret", "helloworld") == "e92eb69939a8b8c9843a75296714af611c73fb53")
+assert(hmac.sha256("secret", "helloworld") == "7a7c2bf41973489be3b318ad2f16c75fc875c340deecb12a3f79b28bb7135c97")
+
+def main():
+	return []
+`
+
+func TestHmac(t *testing.T) {
+	app := &runtime.Applet{}
+	err := app.Load("hmac_test.star", []byte(hmacSource), nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}


### PR DESCRIPTION
There have been several requests to support HMAC in Starlark. After waiting quite a while for [starlib to merge](https://github.com/qri-io/starlib/pull/171) in an HMAC module, I've decided to just bundle it natively in Pixlet.

This is essential for signing requests when using OAuth 1.0; more details are available in the official documentation here: [oauth.net/core/1.0a](https://oauth.net/core/1.0a/#anchor15)

See also: [RFC 2104](https://datatracker.ietf.org/doc/html/rfc2104)