### PR TITLE
fix: Add dummy OAuth2 state.

### DIFF
--- a/src/features/schema/fields/oauth2/OAuth2.jsx
+++ b/src/features/schema/fields/oauth2/OAuth2.jsx
@@ -81,6 +81,7 @@ export default function OAuth2({ field }) {
             authorizationUrl={field.authorization_endpoint}
             responseType="code"
             scope={scope}
+            state="abc123"
             clientId={field.client_id}
             redirectUri={redirectUri}
             render={renderButton}


### PR DESCRIPTION
This commit adds a state parameter for use in OAuth2 requests. The correct flow is that we should generate a random string and then validate on the response. For now, I am adding a generic value to ensure that OAuth2 providers that require the state parameter work as expected.