### PR TITLE
feat: Add palette support.

### DIFF
--- a/src/features/schema/fields/Color.jsx
+++ b/src/features/schema/fields/Color.jsx
@@ -7,9 +7,12 @@ import { set } from '../../config/configSlice';
 
 export default function Color({ field }) {
     const [color, setColor] = useState(createColor(field.default));
+    const [palette, setPalette] = useState(field.palette);
     const config = useSelector(state => state.config);
     const dispatch = useDispatch();
 
+    // TODO: figure out how to update the palette when schema changes without
+    // a refresh.
     useEffect(() => {
         if (field.id in config) {
             setColor(createColor(config[field.id].value));
@@ -36,6 +39,6 @@ export default function Color({ field }) {
     }
 
     return (
-        <ColorPicker value={color} hideTextfield disablePlainColor onChange={onChange} />
+        <ColorPicker value={color} hideTextfield disablePlainColor palette={palette} onChange={onChange} />
     )
 }

--- a/src/features/watcher/watcher.js
+++ b/src/features/watcher/watcher.js
@@ -9,7 +9,7 @@ export default class Watcher {
     }
 
     connect() {
-        const proto =  document.location.protocol === "https:" ? "wss:" : "ws:";
+        const proto = document.location.protocol === "https:" ? "wss:" : "ws:";
         this.conn = new WebSocket(proto + '//' + document.location.host + '/api/v1/ws');
         this.conn.open = this.open.bind(this);
         this.conn.onmessage = this.process.bind(this);


### PR DESCRIPTION
# Overview
This change ensures the color picker can support palettes.

# Changes
- [feat: Add palette support.](https://github.com/tidbyt/pixlet/commit/37df98a49f8cd0f696497e33ece44390937bbb50)
    - The schema field supports a palette, but the color picker did not. This commit adds palette support.

# Demo
<img width="334" alt="Screen Shot 2023-03-22 at 8 55 53 PM" src="https://user-images.githubusercontent.com/3886576/227071888-48af3e98-342d-49a1-b76e-7b1eecbb47c6.png">

# Considerations
This component updates when the redux store updates _config_ but not the schema. This means a change in the palette will require a refresh for now. We have a store for schema, so it should be doable to refresh palettes as well.