### PR TITLE
docs: Add color docs.

### DIFF
--- a/docs/schema/color/example.star
+++ b/docs/schema/color/example.star
@@ -1,0 +1,36 @@
+load("render.star", "render")
+load("schema.star", "schema")
+
+DEFAULT_COLOR = "#FF59FF"
+
+def main(config):
+    color = config.str("color", DEFAULT_COLOR)
+
+    return render.Root(
+        child = render.Box(
+            width = 64,
+            height = 32,
+            color = color,
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Color(
+                id = "color",
+                name = "Color",
+                desc = "Color of the screen.",
+                icon = "brush",
+                default = DEFAULT_COLOR,
+                palette = [
+                    DEFAULT_COLOR,
+                    "#7AB0FF",
+                    "#BFEDC4",
+                    "#78DECC",
+                    "#DBB5FF",
+                ],
+            ),
+        ],
+    )

--- a/docs/schema/schema.md
+++ b/docs/schema/schema.md
@@ -72,6 +72,52 @@ Pixlet offers two types of fields: basic fields like `Toggle` or `Text` and dyna
 ## Fields
 These are the current fields we support through schema today. Note that any addition of a field will require changes in our mobile app before we can truly support them.
 
+### Color
+![color example](color/color.gif)
+> [Example App](color/example.star)
+
+Color provides a color picker. It is provided in `config` as a hex color string with a `#` prefix. The value is ready to use in widgets, like `render.Box()`. 
+
+```starlark
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Color(
+                id = "color",
+                name = "Color",
+                desc = "Color of the screen.",
+                icon = "brush",
+                default = "#7AB0FF",
+            ),
+        ],
+    )
+```
+
+You can also provide an optional `palette` parameter to guide your users towards reasonable color options:
+```starlark
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Color(
+                id = "color",
+                name = "Color",
+                desc = "Color of the screen.",
+                icon = "brush",
+                default = "#7AB0FF",
+                palette = [
+                    "#7AB0FF",
+                    "#BFEDC4",
+                    "#78DECC",
+                    "#DBB5FF",
+                ],
+            ),
+        ],
+    )
+```
+
+
 ### Datetime
 ![datetime example](datetime/datetime.gif)
 > [Example App](datetime/example.star)


### PR DESCRIPTION
# Overview
This change adds docs for the color picker schema field. 

# Changes
- [docs: Add color docs.](https://github.com/tidbyt/pixlet/commit/43167b1e16489e36b0a3745146519d2d65218029)
    - This commit adds docs for the color schema field.