### PR TITLE
Pixlet Create: Add commands to specify path folder for new app (locally)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -11,6 +11,15 @@ import (
 	"tidbyt.dev/pixlet/tools/repo"
 )
 
+var (
+	appDir string
+	usePackageName bool
+)
+
+func init() {
+	CreateCmd.Flags().StringVarP(&appDir,"appDir","","","Path for created app (when not in Tidbyt repos)")
+	CreateCmd.Flags().BoolVarP(&usePackageName,"usePackageName","",false,"Create app in a folder using PackageName (when not in Tidbyt repos)")
+}
 // CreateCmd prompts the user for info and generates a new app.
 var CreateCmd = &cobra.Command{
 	Use:   "create",
@@ -38,6 +47,9 @@ var CreateCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("app creation failed, something went wrong with your tidbyt repo: %w", err)
 			}
+		} else if (appDir!="" || usePackageName) {
+			appType = generator.LocalCustom
+			root = filepath.Join(cwd,appDir)
 		} else {
 			appType = generator.Local
 			root = cwd
@@ -49,6 +61,10 @@ var CreateCmd = &cobra.Command{
 			return fmt.Errorf("app creation, couldn't get user input: %w", err)
 		}
 
+		// Append packageName to create root folder too
+		if (usePackageName && (appType==generator.Local || appType==generator.LocalCustom)){
+			root = filepath.Join(root,app.PackageName)	
+		} 
 		// Generate app.
 		g, err := generator.NewGenerator(appType, root)
 		if err != nil {

--- a/tools/generator/generator.go
+++ b/tools/generator/generator.go
@@ -26,6 +26,8 @@ const (
 	Community AppType = iota
 	// Local represents an app that is local and not meant to be published.
 	Local
+	//LocalCustom is exactly like Local but puts it in a differnt folder/name
+	LocalCustom
 	// Internal represents a Tidbyt internal app.
 	Internal
 )
@@ -62,7 +64,7 @@ func NewGenerator(appType AppType, root string) (*Generator, error) {
 // GenerateApp creates the base app starlark, go package, and updates the app
 // list.
 func (g *Generator) GenerateApp(app *manifest.Manifest) (string, error) {
-	if g.appType == Community || g.appType == Internal {
+	if g.appType == Community || g.appType == Internal || g.appType==LocalCustom {
 		err := g.createDir(app)
 		if err != nil {
 			return "", err
@@ -83,12 +85,24 @@ func (g *Generator) RemoveApp(app *manifest.Manifest) error {
 }
 
 func (g *Generator) createDir(app *manifest.Manifest) error {
-	p := path.Join(g.root, appsDir, app.PackageName)
+	// p := path.Join(g.root, appsDir, app.PackageName)
+	var p string
+	if g.appType==LocalCustom {
+		p = g.root //appDir and/or PackageName is already accounted for here
+	} else {
+		p = path.Join(g.root, appsDir, app.PackageName)
+	}
 	return os.MkdirAll(p, os.ModePerm)
 }
 
 func (g *Generator) removeDir(app *manifest.Manifest) error {
-	p := path.Join(g.root, appsDir, app.PackageName)
+	// p := path.Join(g.root, appsDir, app.PackageName)
+	var p string
+	if g.appType==LocalCustom {
+		p = g.root //appDir and/or PackageName is already accounted for here
+	} else {
+		p = path.Join(g.root, appsDir, app.PackageName)
+	}
 	return os.RemoveAll(p)
 }
 


### PR DESCRIPTION
The behavior for if in tidbyt or community repo should nto be changed. Had to add a few if/else statements to generator.go since appsDir is set to be a constant and was not sure if that would break things internally for tidbyt, so made the changes to fix locally. Also did not want to add more info to the generator structure or app structure

Edit: The two commands added for pixlet create are:

`--appDir` where you specify a path 
`--usePackageName` which stores the new local app in a folder named after `packageName` from the manifest similarly to how it is done if in the community or pixlet repo. 

These commands can be used together or separately. Default is still to create in current working directory though. 