### PR TITLE
td: Handle name changes.

### DIFF
--- a/tools/repo/repo.go
+++ b/tools/repo/repo.go
@@ -124,9 +124,12 @@ func DetermineChanges(dir string, oldCommit string, newCommit string) ([]string,
 
 func getChangeName(change *object.Change) string {
 	var empty = object.ChangeEntry{}
-	if change.From != empty {
-		return change.From.Name
+
+	// Given we skip deletes, this should never be empty. To should be populated
+	// on inserts and modifications.
+	if change.To != empty {
+		return change.To.Name
 	}
 
-	return change.To.Name
+	return change.From.Name
 }


### PR DESCRIPTION
This commit updates the change name to try to use the `To` name first. Given we skip deletes, the to field should always be populated. The library code in question:

```
type Change struct {
	From ChangeEntry
	To   ChangeEntry
}

var empty ChangeEntry

// Action returns the kind of action represented by the change, an
// insertion, a deletion or a modification.
func (c *Change) Action() (merkletrie.Action, error) {
	if c.From == empty && c.To == empty {
		return merkletrie.Action(0),
			fmt.Errorf("malformed change: empty from and to")
	}

	if c.From == empty {
		return merkletrie.Insert, nil
	}

	if c.To == empty {
		return merkletrie.Delete, nil
	}

	return merkletrie.Modify, nil
}
```