### PR TITLE
feat: HTTP Caching Client

### DIFF
--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -29,7 +29,10 @@ func LoadApp(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", script, err)
 	}
-	runtime.InitCache(runtime.NewInMemoryCache())
+
+	cache := runtime.NewInMemoryCache()
+	runtime.InitHTTP(cache)
+	runtime.InitCache(cache)
 
 	applet := runtime.Applet{}
 	err = applet.Load(script, src, nil)

--- a/cmd/community/validateicons.go
+++ b/cmd/community/validateicons.go
@@ -34,7 +34,9 @@ func ValidateIcons(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read app %s: %w", args[0], err)
 	}
 
-	runtime.InitCache(runtime.NewInMemoryCache())
+	cache := runtime.NewInMemoryCache()
+	runtime.InitHTTP(cache)
+	runtime.InitCache(cache)
 
 	applet := runtime.Applet{}
 	err = applet.Load(args[0], src, nil)

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -85,7 +85,9 @@ func profile(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read file %s: %w", script, err)
 	}
 
-	runtime.InitCache(runtime.NewInMemoryCache())
+	cache := runtime.NewInMemoryCache()
+	runtime.InitHTTP(cache)
+	runtime.InitCache(cache)
 
 	applet := runtime.Applet{}
 	err = applet.Load(script, src, nil)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -100,7 +100,9 @@ func render(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read file %s: %w", script, err)
 	}
 
-	runtime.InitCache(runtime.NewInMemoryCache())
+	cache := runtime.NewInMemoryCache()
+	runtime.InitHTTP(cache)
+	runtime.InitCache(cache)
 
 	applet := runtime.Applet{}
 	err = applet.Load(script, src, nil)

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -12,7 +12,6 @@ import (
 	starlibcsv "github.com/qri-io/starlib/encoding/csv"
 	starlibhash "github.com/qri-io/starlib/hash"
 	starlibhtml "github.com/qri-io/starlib/html"
-	starlibhttp "github.com/qri-io/starlib/http"
 	starlibre "github.com/qri-io/starlib/re"
 	starlibjson "go.starlark.net/lib/json"
 	starlibmath "go.starlark.net/lib/math"
@@ -29,6 +28,7 @@ import (
 	"tidbyt.dev/pixlet/runtime/modules/qrcode"
 	"tidbyt.dev/pixlet/runtime/modules/random"
 	"tidbyt.dev/pixlet/runtime/modules/render_runtime"
+	"tidbyt.dev/pixlet/runtime/modules/starlarkhttp"
 	"tidbyt.dev/pixlet/runtime/modules/sunrise"
 	"tidbyt.dev/pixlet/runtime/modules/xpath"
 	"tidbyt.dev/pixlet/schema"
@@ -332,9 +332,9 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 
 	case "hmac.star":
 		return hmac.LoadModule()
-	
+
 	case "http.star":
-		return starlibhttp.LoadModule()
+		return starlarkhttp.LoadModule()
 
 	case "html.star":
 		return starlibhtml.LoadModule()

--- a/runtime/httpcache.go
+++ b/runtime/httpcache.go
@@ -1,0 +1,256 @@
+package runtime
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/httputil"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"tidbyt.dev/pixlet/runtime/modules/starlarkhttp"
+)
+
+const (
+	MinRequestTTL    = 5 * time.Second
+	MaxResponseTTL   = 1 * time.Hour
+	HTTPTimeout      = 5 * time.Second
+	MaxResponseBytes = 20 * 1024 * 1024 // 20MB
+	HTTPCachePrefix  = "httpcache"
+)
+
+// Status codes that are cacheable as defined here:
+// https://developer.mozilla.org/en-US/docs/Glossary/Cacheable
+var cacheableStatusCodes = map[int]bool{
+	200: true,
+	201: true,
+	202: true,
+	203: true,
+	204: true,
+	206: true,
+	300: true,
+	301: true,
+	404: true,
+	405: true,
+	410: true,
+	414: true,
+	429: true, // Not technically cachable, but it is in our system.
+	501: true,
+}
+
+type cacheClient struct {
+	cache     Cache
+	transport http.RoundTripper
+}
+
+func InitHTTP(cache Cache) {
+	cc := &cacheClient{
+		cache:     cache,
+		transport: http.DefaultTransport,
+	}
+
+	httpClient := &http.Client{
+		Transport: cc,
+		Timeout:   HTTPTimeout * 2,
+	}
+	starlarkhttp.StarlarkHTTPClient = httpClient
+}
+
+// RoundTrip is an approximation of what our internal HTTP proxy does. It should
+// behave the same way, and any discrepancy should be considered a bug.
+func (c *cacheClient) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	ctx, cancel := context.WithTimeout(ctx, HTTPTimeout)
+	defer cancel() // need to do this to not leak a goroutine
+
+	key, err := cacheKey(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate cache key: %w", err)
+	}
+
+	if req.Method == "GET" {
+		b, exists, err := c.cache.Get(nil, key)
+		if exists && err == nil {
+			if res, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(b)), req); err == nil {
+				res.Header.Set("tidbyt-cache-status", "HIT")
+				return res, nil
+			}
+		}
+	}
+
+	resp, err := c.transport.RoundTrip(req.WithContext(ctx))
+	if err == nil {
+		resp.Body = http.MaxBytesReader(nil, resp.Body, MaxResponseBytes)
+	}
+
+	if err == nil && req.Method == "GET" {
+		ser, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			// if httputil.DumpResponse fails, it leaves the response body in an
+			// undefined state, so we cannot continue
+			return nil, fmt.Errorf("failed to serialize response for cache: %s", resp.Status)
+		}
+
+		ttl := DetermineTTL(req, resp)
+		c.cache.Set(nil, key, ser, int64(ttl.Seconds()))
+		resp.Header.Set("tidbyt-cache-status", "MISS")
+	}
+
+	return resp, err
+}
+
+func cacheKey(req *http.Request) (string, error) {
+	r, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to serialize request")
+	}
+
+	h := sha256.Sum256(r)
+	key := hex.EncodeToString(h[:])
+
+	app := req.Header.Get("X-Tidbyt-App")
+	if app == "" {
+		return key, nil
+	}
+
+	return fmt.Sprintf("%s:%s:%s", HTTPCachePrefix, app, key), nil
+}
+
+// DetermineTTL determines the TTL for a request based on the request and
+// response. We first check request method / response status code to determine
+// if we should actually cache the response. Then we check the headers passed in
+// from starlark to see if the user configured a TTL. Finally, if the response
+// is cachable but the developer didn't configure a TTL, we check the response
+// to get a hint at what the TTL should be.
+func DetermineTTL(req *http.Request, resp *http.Response) time.Duration {
+	ttl := determineTTL(req, resp)
+
+	// Jitter the TTL by 10% and double check that it's still greater then the
+	// minimum TTL. If it's not, return the minimum TTL. The main thing we want
+	// to avoid is a TTL of 0 given it will be cached forever.
+	ttl = jitterDuration(ttl)
+	if ttl < MinRequestTTL {
+		return MinRequestTTL
+	}
+
+	return ttl
+}
+
+func determineTTL(req *http.Request, resp *http.Response) time.Duration {
+	// Check if the request is cachable.
+	if !isCachable(req, resp) {
+		return MinRequestTTL
+	}
+
+	// If the response is a 429, we want to cache the response for the duration
+	// the remote server told us to wait before retrying.
+	if resp.StatusCode == 429 {
+		retry := MinRequestTTL
+		retryAfter := resp.Header.Get("Retry-After")
+		if retryAfter != "" {
+			if intValue, err := strconv.Atoi(retryAfter); err == nil {
+				retry = time.Duration(intValue) * time.Second
+			}
+		}
+
+		if retry < MinRequestTTL {
+			return MinRequestTTL
+		}
+
+		return retry
+	}
+
+	// Determine the TTL based on the developer's configuration.
+	ttl := determineDeveloperTTL(req)
+
+	// If the developer didn't configure a TTL, determine the TTL based on the
+	// response.
+	if ttl == 0 {
+		ttl = determineResponseTTL(resp)
+	}
+
+	if ttl < MinRequestTTL {
+		return MinRequestTTL
+	}
+
+	return ttl
+}
+
+func jitterDuration(duration time.Duration) time.Duration {
+	jitter := int64(float64(duration) * 0.1)
+	randomJitter := rand.Int63n(2*jitter+1) - jitter
+	return time.Duration(duration + time.Duration(randomJitter))
+}
+
+func determineResponseTTL(resp *http.Response) time.Duration {
+	resHeader := parseCacheControl(resp.Header.Get("Cache-Control"))
+	value, ok := resHeader["max-age"]
+	if ok {
+		if intValue, ok := value.(int); ok {
+			ttl := time.Duration(intValue) * time.Second
+
+			// If we're using a response TTL, we're making the assumption that
+			// the remote server is providing a reasonable TTL that a developer
+			// didn't configure. In the case of weathermap, the TTL is 1 week,
+			// but the developer is requesting a new map ever hour. So while the
+			// old map _is_ valid for a week, we the app only cares about it for
+			// one hour.
+			if ttl > MaxResponseTTL {
+				return MaxResponseTTL
+			}
+			return ttl
+		}
+	}
+
+	return 0
+}
+
+func determineDeveloperTTL(req *http.Request) time.Duration {
+	ttlHeader := req.Header.Get("X-Tidbyt-Cache-Seconds")
+	if ttlHeader != "" {
+		if intValue, err := strconv.Atoi(ttlHeader); err == nil {
+			return time.Duration(intValue) * time.Second
+		}
+	}
+
+	return 0
+}
+
+func isCachable(req *http.Request, resp *http.Response) bool {
+	if !(req.Method == "GET" || req.Method == "HEAD") {
+		return false
+	}
+
+	_, ok := cacheableStatusCodes[resp.StatusCode]
+	return ok
+}
+
+func parseCacheControl(header string) map[string]interface{} {
+	directives := make(map[string]interface{})
+
+	for _, directive := range strings.Split(header, ",") {
+		parts := strings.SplitN(strings.TrimSpace(directive), "=", 2)
+
+		key := strings.ToLower(parts[0])
+		var value interface{} = true
+
+		if len(parts) > 1 {
+			value = parts[1]
+			if intValue, err := strconv.Atoi(parts[1]); err == nil {
+				value = intValue
+			}
+		}
+
+		directives[key] = value
+	}
+
+	return directives
+}

--- a/runtime/httpcache_test.go
+++ b/runtime/httpcache_test.go
@@ -1,0 +1,170 @@
+package runtime
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitHTTP(t *testing.T) {
+	c := NewInMemoryCache()
+	InitHTTP(c)
+
+	b, err := os.ReadFile("testdata/httpcache.star")
+	assert.NoError(t, err)
+
+	app := &Applet{}
+	err = app.Load("httpcache.star", b, nil)
+	assert.NoError(t, err)
+
+	screens, err := app.Run(map[string]string{})
+	assert.NoError(t, err)
+	assert.NotNil(t, screens)
+}
+
+// TestDetermineTTL tests the DetermineTTL function.
+func TestDetermineTTL(t *testing.T) {
+	type test struct {
+		ttl         int
+		retryAfter  int
+		resHeader   string
+		statusCode  int
+		method      string
+		expectedTTL time.Duration
+	}
+
+	tests := map[string]test{
+		"test request cache control headers": {
+			ttl:         3600,
+			resHeader:   "",
+			statusCode:  200,
+			method:      "GET",
+			expectedTTL: 3600 * time.Second,
+		},
+		"test response cache control headers": {
+			ttl:         0,
+			resHeader:   "public, max-age=3600, s-maxage=7200, no-transform",
+			statusCode:  200,
+			method:      "GET",
+			expectedTTL: 3600 * time.Second,
+		},
+		"test too long response cache control headers": {
+			ttl:         0,
+			resHeader:   "max-age=604800",
+			statusCode:  200,
+			method:      "GET",
+			expectedTTL: 3600 * time.Second,
+		},
+		"test max-age of zero": {
+			ttl:         0,
+			resHeader:   "max-age=0",
+			statusCode:  200,
+			method:      "GET",
+			expectedTTL: 5 * time.Second,
+		},
+		"test both request and response cache control headers": {
+			ttl:         3600,
+			resHeader:   "public, max-age=60, s-maxage=7200, no-transform",
+			statusCode:  200,
+			method:      "GET",
+			expectedTTL: 3600 * time.Second,
+		},
+		"test 500 response code": {
+			ttl:         3600,
+			resHeader:   "",
+			statusCode:  500,
+			method:      "GET",
+			expectedTTL: 5 * time.Second,
+		},
+		"test too low ttl": {
+			ttl:         3,
+			resHeader:   "",
+			statusCode:  200,
+			method:      "GET",
+			expectedTTL: 5 * time.Second,
+		},
+		"test DELETE request": {
+			ttl:         30,
+			resHeader:   "",
+			statusCode:  200,
+			method:      "DELETE",
+			expectedTTL: 5 * time.Second,
+		},
+		"test 429 request": {
+			ttl:         30,
+			retryAfter:  60,
+			resHeader:   "",
+			statusCode:  429,
+			method:      "GET",
+			expectedTTL: 60 * time.Second,
+		},
+		"test 429 request below minimum": {
+			ttl:         30,
+			retryAfter:  3,
+			resHeader:   "",
+			statusCode:  429,
+			method:      "GET",
+			expectedTTL: 5 * time.Second,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := &http.Request{
+				Header: map[string][]string{
+					"X-Tidbyt-Cache-Seconds": {fmt.Sprintf("%d", tc.ttl)},
+				},
+				Method: tc.method,
+			}
+
+			res := &http.Response{
+				Header: map[string][]string{
+					"Cache-Control": {tc.resHeader},
+				},
+				StatusCode: tc.statusCode,
+			}
+
+			if tc.retryAfter > 0 {
+				res.Header.Set("Retry-After", fmt.Sprintf("%d", tc.retryAfter))
+			}
+
+			ttl := determineTTL(req, res)
+			assert.Equal(t, tc.expectedTTL, ttl)
+		})
+	}
+}
+
+func TestDetermineTTLJitter(t *testing.T) {
+	req := &http.Request{
+		Header: map[string][]string{
+			"X-Tidbyt-Cache-Seconds": {"60"},
+		},
+		Method: "GET",
+	}
+
+	res := &http.Response{
+		StatusCode: 200,
+	}
+
+	rand.Seed(50)
+	ttl := DetermineTTL(req, res)
+	assert.Equal(t, 64, int(ttl.Seconds()))
+}
+
+func TestDetermineTTLNoHeaders(t *testing.T) {
+	req := &http.Request{
+		Method: "GET",
+	}
+
+	res := &http.Response{
+		StatusCode: 200,
+	}
+
+	ttl := DetermineTTL(req, res)
+	assert.Equal(t, MinRequestTTL, ttl)
+}

--- a/runtime/modules/starlarkhttp/starlarkhttp.go
+++ b/runtime/modules/starlarkhttp/starlarkhttp.go
@@ -1,0 +1,433 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 QRI, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package starlarkhttp
+
+// This module uses qri-io/starlib's http module as a base, and adds Tidbyt
+// specific headers to all requests.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	util "github.com/qri-io/starlib/util"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// AsString unquotes a starlark string value
+func AsString(x starlark.Value) (string, error) {
+	return strconv.Unquote(x.String())
+}
+
+// ModuleName defines the expected name for this Module when used
+// in starlark's load() function, eg: load('http.star', 'http')
+const ModuleName = "http.star"
+
+var (
+	// StarlarkHTTPClient is the http client used to create the http module. override with
+	// a custom client before calling LoadModule
+	StarlarkHTTPClient = http.DefaultClient
+	// StarlarkHTTPGuard is a global RequestGuard used in LoadModule. override with a custom
+	// implementation before calling LoadModule
+	StarlarkHTTPGuard RequestGuard
+)
+
+// Encodings for form data.
+//
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
+const (
+	formEncodingMultipart = "multipart/form-data"
+	formEncodingURL       = "application/x-www-form-urlencoded"
+)
+
+// LoadModule creates an http Module
+func LoadModule() (starlark.StringDict, error) {
+	var m = &Module{cli: StarlarkHTTPClient}
+	if StarlarkHTTPGuard != nil {
+		m.rg = StarlarkHTTPGuard
+	}
+	ns := starlark.StringDict{
+		"http": m.Struct(),
+	}
+	return ns, nil
+}
+
+// RequestGuard controls access to http by checking before making requests
+// if Allowed returns an error the request will be denied
+type RequestGuard interface {
+	Allowed(thread *starlark.Thread, req *http.Request) (*http.Request, error)
+}
+
+// Module joins http tools to a dataset, allowing dataset
+// to follow along with http requests
+type Module struct {
+	cli *http.Client
+	rg  RequestGuard
+}
+
+// Struct returns this module's methods as a starlark Struct
+func (m *Module) Struct() *starlarkstruct.Struct {
+	return starlarkstruct.FromStringDict(starlarkstruct.Default, m.StringDict())
+}
+
+// StringDict returns all module methods in a starlark.StringDict
+func (m *Module) StringDict() starlark.StringDict {
+	return starlark.StringDict{
+		"get":     starlark.NewBuiltin("get", m.reqMethod("get")),
+		"put":     starlark.NewBuiltin("put", m.reqMethod("put")),
+		"post":    starlark.NewBuiltin("post", m.reqMethod("post")),
+		"delete":  starlark.NewBuiltin("delete", m.reqMethod("delete")),
+		"patch":   starlark.NewBuiltin("patch", m.reqMethod("patch")),
+		"options": starlark.NewBuiltin("options", m.reqMethod("options")),
+	}
+}
+
+// reqMethod is a factory function for generating starlark builtin functions for different http request methods
+func (m *Module) reqMethod(method string) func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var (
+			urlv         starlark.String
+			params       = &starlark.Dict{}
+			headers      = &starlark.Dict{}
+			formBody     = &starlark.Dict{}
+			formEncoding starlark.String
+			auth         starlark.Tuple
+			body         starlark.String
+			jsonBody     starlark.Value
+			ttl          starlark.Int
+		)
+
+		if err := starlark.UnpackArgs(method, args, kwargs, "url", &urlv, "params?", &params, "headers", &headers, "body", &body, "form_body", &formBody, "form_encoding", &formEncoding, "json_body", &jsonBody, "auth", &auth, "ttl_seconds?", &ttl); err != nil {
+			return nil, err
+		}
+
+		rawurl, err := AsString(urlv)
+		if err != nil {
+			return nil, err
+		}
+		if err = setQueryParams(&rawurl, params); err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequest(strings.ToUpper(method), rawurl, nil)
+		if err != nil {
+			return nil, err
+		}
+		if m.rg != nil {
+			req, err = m.rg.Allowed(thread, req)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if err = setHeaders(req, headers); err != nil {
+			return nil, err
+		}
+		if err = setStandardHeaders(req, thread, ttl); err != nil {
+			return nil, err
+		}
+		if err = setAuth(req, auth); err != nil {
+			return nil, err
+		}
+		if err = SetBody(req, body, formBody, formEncoding, jsonBody); err != nil {
+			return nil, err
+		}
+
+		res, err := m.cli.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		r := &Response{*res}
+		return r.Struct(), nil
+	}
+}
+
+func setQueryParams(rawurl *string, params *starlark.Dict) error {
+	keys := params.Keys()
+	if len(keys) == 0 {
+		return nil
+	}
+
+	u, err := url.Parse(*rawurl)
+	if err != nil {
+		return err
+	}
+
+	q := u.Query()
+	for _, key := range keys {
+		keystr, err := AsString(key)
+		if err != nil {
+			return err
+		}
+
+		val, _, err := params.Get(key)
+		if err != nil {
+			return err
+		}
+		if val.Type() != "string" {
+			return fmt.Errorf("expected param value for key '%s' to be a string. got: '%s'", key, val.Type())
+		}
+		valstr, err := AsString(val)
+		if err != nil {
+			return err
+		}
+
+		q.Set(keystr, valstr)
+	}
+
+	u.RawQuery = q.Encode()
+	*rawurl = u.String()
+	return nil
+}
+
+func setAuth(req *http.Request, auth starlark.Tuple) error {
+	if len(auth) == 0 {
+		return nil
+	} else if len(auth) == 2 {
+		username, err := AsString(auth[0])
+		if err != nil {
+			return fmt.Errorf("parsing auth username string: %s", err.Error())
+		}
+		password, err := AsString(auth[1])
+		if err != nil {
+			return fmt.Errorf("parsing auth password string: %s", err.Error())
+		}
+		req.SetBasicAuth(username, password)
+		return nil
+	}
+	return fmt.Errorf("expected two values for auth params tuple")
+}
+
+func setStandardHeaders(req *http.Request, thread *starlark.Thread, ttl starlark.Int) error {
+	// Set app identifier.
+	req.Header.Set("X-Tidbyt-App", getAppIdentifier(thread))
+
+	// Set ttl for caching client.
+	ttl64, ok := ttl.Int64()
+	if !ok {
+		return fmt.Errorf("ttl_seconds must be valid integer (not %s)", ttl.String())
+	}
+	req.Header.Set("X-Tidbyt-Cache-Seconds", fmt.Sprintf("%d", ttl64))
+
+	return nil
+}
+
+func getAppIdentifier(thread *starlark.Thread) string {
+	parts := strings.Split(thread.Name, "/")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+
+	return thread.Name
+}
+
+func setHeaders(req *http.Request, headers *starlark.Dict) error {
+	keys := headers.Keys()
+	if len(keys) == 0 {
+		return nil
+	}
+
+	for _, key := range keys {
+		keystr, err := AsString(key)
+		if err != nil {
+			return err
+		}
+
+		val, _, err := headers.Get(key)
+		if err != nil {
+			return err
+		}
+		if val.Type() != "string" {
+			return fmt.Errorf("expected param value for key '%s' to be a string. got: '%s'", key, val.Type())
+		}
+		valstr, err := AsString(val)
+		if err != nil {
+			return err
+		}
+
+		req.Header.Add(keystr, valstr)
+	}
+
+	return nil
+}
+
+func SetBody(req *http.Request, body starlark.String, formData *starlark.Dict, formEncoding starlark.String, jsondata starlark.Value) error {
+	if !util.IsEmptyString(body) {
+		uq, err := strconv.Unquote(body.String())
+		if err != nil {
+			return err
+		}
+		req.Body = io.NopCloser(strings.NewReader(uq))
+		// Specifying the Content-Length ensures that https://go.dev/src/net/http/transfer.go doesnt specify Transfer-Encoding: chunked which is not supported by some endpoints.
+		// This is required when using io.NopCloser method for the request body (see ShouldSendChunkedRequestBody() in the library mentioned above).
+		req.ContentLength = int64(len(uq))
+
+		return nil
+	}
+
+	if jsondata != nil && jsondata.String() != "" {
+		req.Header.Set("Content-Type", "application/json")
+
+		v, err := util.Unmarshal(jsondata)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		req.Body = io.NopCloser(bytes.NewBuffer(data))
+		req.ContentLength = int64(len(data))
+	}
+
+	if formData != nil && formData.Len() > 0 {
+		form := url.Values{}
+		for _, key := range formData.Keys() {
+			keystr, err := AsString(key)
+			if err != nil {
+				return err
+			}
+
+			val, _, err := formData.Get(key)
+			if err != nil {
+				return err
+			}
+			if val.Type() != "string" {
+				return fmt.Errorf("expected param value for key '%s' to be a string. got: '%s'", key, val.Type())
+			}
+			valstr, err := AsString(val)
+			if err != nil {
+				return err
+			}
+
+			form.Add(keystr, valstr)
+		}
+
+		var contentType string
+		switch formEncoding {
+		case formEncodingURL, "":
+			contentType = formEncodingURL
+			req.Body = io.NopCloser(strings.NewReader(form.Encode()))
+			req.ContentLength = int64(len(form.Encode()))
+
+		case formEncodingMultipart:
+			var b bytes.Buffer
+			mw := multipart.NewWriter(&b)
+			defer mw.Close()
+
+			contentType = mw.FormDataContentType()
+
+			for k, values := range form {
+				for _, v := range values {
+					w, err := mw.CreateFormField(k)
+					if err != nil {
+						return err
+					}
+					if _, err := w.Write([]byte(v)); err != nil {
+						return err
+					}
+				}
+			}
+
+			req.Body = io.NopCloser(&b)
+
+		default:
+			return fmt.Errorf("unknown form encoding: %s", formEncoding)
+		}
+
+		if req.Header.Get("Content-Type") == "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+	}
+
+	return nil
+}
+
+// Response represents an HTTP response, wrapping a go http.Response with
+// starlark methods
+type Response struct {
+	http.Response
+}
+
+// Struct turns a response into a *starlark.Struct
+func (r *Response) Struct() *starlarkstruct.Struct {
+	return starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+		"url":         starlark.String(r.Request.URL.String()),
+		"status_code": starlark.MakeInt(r.StatusCode),
+		"headers":     r.HeadersDict(),
+		"encoding":    starlark.String(strings.Join(r.TransferEncoding, ",")),
+
+		"body": starlark.NewBuiltin("body", r.Text),
+		"json": starlark.NewBuiltin("json", r.JSON),
+	})
+}
+
+// HeadersDict flops
+func (r *Response) HeadersDict() *starlark.Dict {
+	d := new(starlark.Dict)
+	for key, vals := range r.Header {
+		if err := d.SetKey(starlark.String(key), starlark.String(strings.Join(vals, ","))); err != nil {
+			panic(err)
+		}
+	}
+	return d
+}
+
+// Text returns the raw data as a string
+func (r *Response) Text(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body.Close()
+	// reset reader to allow multiple calls
+	r.Body = io.NopCloser(bytes.NewReader(data))
+
+	return starlark.String(string(data)), nil
+}
+
+// JSON attempts to parse the response body as JSON
+func (r *Response) JSON(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var data interface{}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, err
+	}
+	r.Body.Close()
+	// reset reader to allow multiple calls
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return util.Marshal(data)
+}

--- a/runtime/modules/starlarkhttp/starlarkhttp_test.go
+++ b/runtime/modules/starlarkhttp/starlarkhttp_test.go
@@ -1,0 +1,142 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 QRI, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package starlarkhttp_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qri-io/starlib/testdata"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
+	"tidbyt.dev/pixlet/runtime/modules/starlarkhttp"
+)
+
+func TestAsString(t *testing.T) {
+	cases := []struct {
+		in       starlark.Value
+		got, err string
+	}{
+		{starlark.String("foo"), "foo", ""},
+		{starlark.String("\"foo'"), "\"foo'", ""},
+		{starlark.Bool(true), "", "invalid syntax"},
+	}
+
+	for i, c := range cases {
+		got, err := starlarkhttp.AsString(c.in)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if c.got != got {
+			t.Errorf("case %d. expected: '%s', got: '%s'", i, c.got, got)
+		}
+	}
+}
+
+func TestNewModule(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Date", "Mon, 01 Jun 2000 00:00:00 GMT")
+		if _, err := w.Write([]byte(`{"hello":"world"}`)); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	starlark.Universe["test_server_url"] = starlark.String(ts.URL)
+
+	thread := &starlark.Thread{Name: "unittests/abc123", Load: testdata.NewLoader(starlarkhttp.LoadModule, starlarkhttp.ModuleName)}
+	starlarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// we're ok with testing private functions if it simplifies the test :)
+func TestSetBody(t *testing.T) {
+	fd := map[string]string{
+		"foo": "bar baz",
+	}
+
+	cases := []struct {
+		rawBody      starlark.String
+		formData     map[string]string
+		formEncoding starlark.String
+		jsonData     starlark.Value
+		body         string
+		err          string
+	}{
+		{starlark.String("hallo"), nil, starlark.String(""), nil, "hallo", ""},
+		{starlark.String(""), fd, starlark.String(""), nil, "foo=bar+baz", ""},
+		// TODO - this should check multipart form data is being set
+		{starlark.String(""), fd, starlark.String("multipart/form-data"), nil, "", ""},
+		{starlark.String(""), nil, starlark.String(""), starlark.Tuple{starlark.Bool(true), starlark.MakeInt(1), starlark.String("der")}, "[true,1,\"der\"]", ""},
+	}
+
+	for i, c := range cases {
+		var formData *starlark.Dict
+		if c.formData != nil {
+			formData = starlark.NewDict(len(c.formData))
+			for k, v := range c.formData {
+				if err := formData.SetKey(starlark.String(k), starlark.String(v)); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		req := httptest.NewRequest("get", "https://example.com", nil)
+		err := starlarkhttp.SetBody(req, c.rawBody, formData, c.formEncoding, c.jsonData)
+		if !(err == nil && c.err == "" || (err != nil && err.Error() == c.err)) {
+			t.Errorf("case %d error mismatch. expected: %s, got: %s", i, c.err, err)
+			continue
+		}
+
+		if strings.HasPrefix(req.Header.Get("Content-Type"), "multipart/form-data;") {
+			if err := req.ParseMultipartForm(0); err != nil {
+				t.Fatal(err)
+			}
+
+			for k, v := range c.formData {
+				fv := req.FormValue(k)
+				if fv != v {
+					t.Errorf("case %d error mismatch. expected %s=%s, got: %s", i, k, v, fv)
+				}
+			}
+		} else {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(body) != c.body {
+				t.Errorf("case %d body mismatch. expected: %s, got: %s", i, c.body, string(body))
+			}
+		}
+	}
+}

--- a/runtime/modules/starlarkhttp/testdata/test.star
+++ b/runtime/modules/starlarkhttp/testdata/test.star
@@ -1,0 +1,17 @@
+load("http.star", "http")
+load("assert.star", "assert")
+
+res_1 = http.get(test_server_url, params = {"a": "b", "c": "d"})
+assert.eq(res_1.url, test_server_url + "?a=b&c=d")
+assert.eq(res_1.status_code, 200)
+assert.eq(res_1.body(), '{"hello":"world"}')
+assert.eq(res_1.json(), {"hello": "world"})
+
+assert.eq(res_1.headers, {"Date": "Mon, 01 Jun 2000 00:00:00 GMT", "Content-Length": "17", "Content-Type": "text/plain; charset=utf-8"})
+
+res_2 = http.get(test_server_url)
+assert.eq(res_2.json()["hello"], "world")
+
+headers = {"foo": "bar"}
+http.post(test_server_url, json_body = {"a": "b", "c": "d"}, headers = headers)
+http.post(test_server_url, form_body = {"a": "b", "c": "d"})

--- a/runtime/testdata/httpcache.star
+++ b/runtime/testdata/httpcache.star
@@ -1,0 +1,30 @@
+"""
+Applet: Test App
+Summary: For Testing
+Description: It's an app for testing.
+Author: Test Dev
+"""
+
+load("render.star", "render")
+load("http.star", "http")
+load("assert.star", "assert")
+
+def main(config):
+    resp = http.get(
+        url = "https://example.com",
+        ttl_seconds = 60,
+    )
+    assert.eq(resp.headers.get("Tidbyt-Cache-Status"), "MISS")
+
+    resp = http.get(
+        url = "https://example.com",
+        ttl_seconds = 60,
+    )
+    assert.eq(resp.headers.get("Tidbyt-Cache-Status"), "HIT")
+
+    return render.Root(
+        child = render.Box(
+            width = 64,
+            height = 32,
+        ),
+    )

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -59,7 +59,9 @@ func NewLoader(
 		maxDuration:      maxDuration,
 	}
 
-	runtime.InitCache(runtime.NewInMemoryCache())
+	cache := runtime.NewInMemoryCache()
+	runtime.InitHTTP(cache)
+	runtime.InitCache(cache)
 
 	if !l.watch {
 		err := loadScript(&l.applet, l.filename)


### PR DESCRIPTION
# Overview
Tidbyt operates a shared platform that makes requests to external providers. Left unchecked, the number of outgoing HTTP requests an app can make can grow quite large. To make it easier to cache outgoing HTTP requests, we're making it part of the client. In addition, we've set some defaults to ensure that we respect 429s, infer intent from cache control headers, and set sane limits on how frequently an app can make requests. 

# Considerations
Some of the code in this change is simply an approximation of our internal proxy. However, any discrepancy should be considered a bug.

# Demo
In the old style, this would require the separate `cache.star` module, the developer to come up with a sane cache key, and the developer to encode/decode the cache values. Now, it's a single line change:
```
    resp = http.get(
        url = "https://example.com",
        ttl_seconds = 60,
    )
```

# Changes
- [http: Vendor starlib http client.](https://github.com/tidbyt/pixlet/commit/6c6ae02265be8d388c3e783b5eb0ff7ba173895d) 
    - This commit vendors in the starlib http client and adds in Tidbyt specific headers. These are used by our caching client to make decisions about how to cache HTTP requests.
- [http: Add caching client that mimics internal proxy.](https://github.com/tidbyt/pixlet/commit/4bec7d31c1e4a144d238251539c2d41fdcc6e620) 
    - This commit adds a caching HTTP client that mimics our internal proxy.
- [http: Wire in caching http client.](https://github.com/tidbyt/pixlet/commit/faf2331ea8cbf1513eefa5837593279d0461ff89)
    - This commit wires in the http client into all of the places that need a new app runtime.

# Tests
This client has been running in our production environment for several weeks. This change simply makes it public and part of  pixlet so developers can start configuring a TTL as part of their apps.