### PR TITLE
http: Support caching POST requests.

### DIFF
--- a/runtime/httpcache_test.go
+++ b/runtime/httpcache_test.go
@@ -89,10 +89,24 @@ func TestDetermineTTL(t *testing.T) {
 			expectedTTL: 5 * time.Second,
 		},
 		"test DELETE request": {
-			ttl:         30,
+			ttl:         0,
 			resHeader:   "",
 			statusCode:  200,
 			method:      "DELETE",
+			expectedTTL: 5 * time.Second,
+		},
+		"test POST request configured with TTL": {
+			ttl:         30,
+			resHeader:   "",
+			statusCode:  200,
+			method:      "POST",
+			expectedTTL: 30 * time.Second,
+		},
+		"test POST request without configured TTL": {
+			ttl:         0,
+			resHeader:   "",
+			statusCode:  200,
+			method:      "POST",
 			expectedTTL: 5 * time.Second,
 		},
 		"test 429 request": {

--- a/runtime/testdata/httpcache.star
+++ b/runtime/testdata/httpcache.star
@@ -22,6 +22,24 @@ def main(config):
     )
     assert.eq(resp.headers.get("Tidbyt-Cache-Status"), "HIT")
 
+    resp = http.post(
+        url = "https://example.com",
+        ttl_seconds = 0,
+    )
+    assert.eq(resp.headers.get("Tidbyt-Cache-Status"), "MISS")
+
+    resp = http.post(
+        url = "https://example.com",
+        ttl_seconds = 60,
+    )
+    assert.eq(resp.headers.get("Tidbyt-Cache-Status"), "MISS")
+
+    resp = http.post(
+        url = "https://example.com",
+        ttl_seconds = 60,
+    )
+    assert.eq(resp.headers.get("Tidbyt-Cache-Status"), "HIT")
+
     return render.Root(
         child = render.Box(
             width = 64,


### PR DESCRIPTION
This commit supports caching POST requests, though only if the user explicitly sets the TTL.