### PR TITLE
location: Truncate location values.

### DIFF
--- a/src/features/schema/fields/location/LocationBased.jsx
+++ b/src/features/schema/fields/location/LocationBased.jsx
@@ -14,14 +14,14 @@ import { callHandler } from '../../../handlers/actions';
 
 export default function LocationBased({ field }) {
     const [locationValue, setLocationValue] = useState({
-    	// Default to Brooklyn, because that's where tidbyt folks
-    	// are and  we can only dispatch a location object which
-    	// has all fields set.
-    	'lat': 40.6782,
-    	'lng': -73.9442,
-    	'locality': 'Brooklyn, New York',
-    	'timezone': 'America/New_York'
-   	});
+        // Default to Brooklyn, because that's where tidbyt folks
+        // are and  we can only dispatch a location object which
+        // has all fields set.
+        'lat': 40.678,
+        'lng': -73.944,
+        'locality': 'Brooklyn, New York',
+        'timezone': 'America/New_York'
+    });
 
     const [value, setValue] = useState(field.default);
 
@@ -42,33 +42,37 @@ export default function LocationBased({ field }) {
     }, [])
 
     const setPart = (partName, partValue) => {
-    	let newLocationValue = {...locationValue};
-    	newLocationValue[partName] = partValue;
-    	setLocationValue(newLocationValue);
+        let newLocationValue = { ...locationValue };
+        newLocationValue[partName] = partValue;
+        setLocationValue(newLocationValue);
         callHandler(field.id, field.handler, JSON.stringify(newLocationValue));
     }
 
+    const truncateLatLng = (value) => {
+        return String(Number(value).toFixed(3));
+    }
+
     const onChangeLatitude = (event) => {
-        setPart('lat', event.target.value);
+        setPart('lat', truncateLatLng(event.target.value));
     }
 
     const onChangeLongitude = (event) => {
-    	setPart('lng', event.target.value);
+        setPart('lng', truncateLatLng(event.target.value));
     }
 
     const onChangeLocality = (event) => {
-    	setPart('locality', event.target.value);
+        setPart('locality', event.target.value);
     }
 
     const onChangeTimezone = (event) => {
-    	setPart('timezone', event.target.value);
+        setPart('timezone', event.target.value);
     }
 
     const onChangeOption = (event) => {
         setValue(event.target.value);
         dispatch(set({
             id: field.id,
-            value: JSON.stringify({'value': event.target.value})
+            value: JSON.stringify({ 'value': event.target.value })
         }));
     }
 
@@ -81,34 +85,34 @@ export default function LocationBased({ field }) {
         <FormControl fullWidth>
             <Typography>Latitude</Typography>
             <InputSlider
-            	min={-90}
-            	max={90}
-            	step={0.1}
-            	onChange={onChangeLatitude}
-            	defaultValue={locationValue['lat']}
+                min={-90}
+                max={90}
+                step={0.1}
+                onChange={onChangeLatitude}
+                defaultValue={locationValue['lat']}
             >
             </InputSlider>
             <Typography>Longitude</Typography>
             <InputSlider
-            	min={-180}
-            	max={180}
-            	step={0.1}
-            	onChange={onChangeLongitude}
-            	defaultValue={locationValue['lng']}
+                min={-180}
+                max={180}
+                step={0.1}
+                onChange={onChangeLongitude}
+                defaultValue={locationValue['lng']}
             >
             </InputSlider>
             <Typography>Locality</Typography>
             <TextField
-            	fullWidth
-            	variant="outlined"
-            	onChange={onChangeLocality}
-            	style={{ marginBottom: '0.5rem' }} 
-            	defaultValue={locationValue['locality']}
+                fullWidth
+                variant="outlined"
+                onChange={onChangeLocality}
+                style={{ marginBottom: '0.5rem' }}
+                defaultValue={locationValue['locality']}
             />
             <Typography>Timezone</Typography>
             <Select
                 onChange={onChangeTimezone}
-                style={{ marginBottom: '0.5rem' }} 
+                style={{ marginBottom: '0.5rem' }}
                 defaultValue={locationValue['timezone']}
             >
                 {Intl.supportedValuesOf('timeZone').map((zone) => {

--- a/src/features/schema/fields/location/LocationForm.jsx
+++ b/src/features/schema/fields/location/LocationForm.jsx
@@ -13,16 +13,16 @@ import { set } from '../../../config/configSlice';
 
 export default function LocationForm({ field }) {
     const [value, setValue] = useState({
-    	// Default to Brooklyn, because that's where tidbyt folks
-    	// are and  we can only dispatch a location object which
-    	// has all fields set.
-    	'lat': 40.6782,
-    	'lng': -73.9442,
-    	'locality': 'Brooklyn, New York',
-    	'timezone': 'America/New_York',
-    	// But overwrite with app-specific defaults set in config.
-    	...field.default
-   	});
+        // Default to Brooklyn, because that's where tidbyt folks
+        // are and  we can only dispatch a location object which
+        // has all fields set.
+        'lat': 40.678,
+        'lng': -73.944,
+        'locality': 'Brooklyn, New York',
+        'timezone': 'America/New_York',
+        // But overwrite with app-specific defaults set in config.
+        ...field.default
+    });
 
     const config = useSelector(state => state.config);
 
@@ -40,58 +40,62 @@ export default function LocationForm({ field }) {
     }, [])
 
     const setPart = (partName, partValue) => {
-    	let newValue = {...value};
-    	newValue[partName] = partValue;
-    	setValue(newValue);
-    	dispatch(set({
-    		id: field.id,
-    		value: JSON.stringify(newValue),
-    	}));
+        let newValue = { ...value };
+        newValue[partName] = partValue;
+        setValue(newValue);
+        dispatch(set({
+            id: field.id,
+            value: JSON.stringify(newValue),
+        }));
+    }
+
+    const truncateLatLng = (value) => {
+        return String(Number(value).toFixed(3));
     }
 
     const onChangeLatitude = (event) => {
-        setPart('lat', event.target.value);
+        setPart('lat', truncateLatLng(event.target.value));
     }
 
     const onChangeLongitude = (event) => {
-    	setPart('lng', event.target.value);
+        setPart('lng', truncateLatLng(event.target.value));
     }
 
     const onChangeLocality = (event) => {
-    	setPart('locality', event.target.value);
+        setPart('locality', event.target.value);
     }
 
     const onChangeTimezone = (event) => {
-    	setPart('timezone', event.target.value);
+        setPart('timezone', event.target.value);
     }
 
     return (
         <FormControl fullWidth>
             <Typography>Latitude</Typography>
             <InputSlider
-            	min={-90}
-            	max={90}
-            	step={0.1}
-            	onChange={onChangeLatitude}
-            	defaultValue={value['lat']}
+                min={-90}
+                max={90}
+                step={0.1}
+                onChange={onChangeLatitude}
+                defaultValue={value['lat']}
             >
             </InputSlider>
             <Typography>Longitude</Typography>
             <InputSlider
-            	min={-180}
-            	max={180}
-            	step={0.1}
-            	onChange={onChangeLongitude}
-            	defaultValue={value['lng']}
+                min={-180}
+                max={180}
+                step={0.1}
+                onChange={onChangeLongitude}
+                defaultValue={value['lng']}
             >
             </InputSlider>
             <Typography>Locality</Typography>
             <TextField
-            	fullWidth
-            	variant="outlined"
-            	onChange={onChangeLocality}
-            	style={{ marginBottom: '0.5rem' }} 
-            	defaultValue={value['locality']}
+                fullWidth
+                variant="outlined"
+                onChange={onChangeLocality}
+                style={{ marginBottom: '0.5rem' }}
+                defaultValue={value['locality']}
             />
             <Typography>Timezone</Typography>
             <Select


### PR DESCRIPTION
# Overview
We're rolling out changes to truncate location values across the board to prevent leaking PII to third parties and making it one less thing for Tidbyt engineers to review during the PR process.

# Changes
- [location: Truncate location values.](https://github.com/tidbyt/pixlet/commit/82ca89488305e54144a299d60e80b33563da4be4)
    - This commit truncates location values provided in the pixlet editor to use 3 decimal points.