### PR TITLE
feat: Add controls to web view.

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -13,6 +13,7 @@ import ParamSetter from './features/config/ParamSetter';
 import Preview from './features/preview/Preview';
 import Schema from './features/schema/Schema';
 import WatcherManager from './features/watcher/WatcherManager';
+import Controls from './features/controls/Controls';
 
 
 export default function Main() {
@@ -36,6 +37,7 @@ export default function Main() {
                     <Grid container spacing={4}>
                         <Grid item xs={12} lg={size}>
                             <Preview scale={10} />
+                            <Controls />
                         </Grid>
                         <Grid item xs={12} lg={4}>
                             <Schema />

--- a/src/features/controls/Controls.jsx
+++ b/src/features/controls/Controls.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { Button, Stack, Grid } from '@mui/material';
+
+export default function Controls() {
+    const preview = useSelector(state => state.preview);
+
+    function downloadPreview() {
+        const date = new Date().getTime();
+        const element = document.createElement("a");
+
+        // convert base64 to raw binary data held in a string
+        let byteCharacters = atob(preview.value.webp);
+
+        // create an ArrayBuffer with a size in bytes
+        let arrayBuffer = new ArrayBuffer(byteCharacters.length);
+
+        // create a new Uint8Array view
+        let uint8Array = new Uint8Array(arrayBuffer);
+
+        // assign the values
+        for (let i = 0; i < byteCharacters.length; i++) {
+            uint8Array[i] = byteCharacters.charCodeAt(i);
+        }
+
+        const file = new Blob([uint8Array], { type: 'image/webp' });
+        element.href = URL.createObjectURL(file);
+        element.download = `tidbyt-preview-${date}.webp`;
+        document.body.appendChild(element); // Required for this to work in FireFox
+        element.click();
+    }
+
+    function resetSchema() {
+        history.replaceState(null, '', location.pathname);
+        window.location.reload();
+    }
+
+    return (
+        <Stack sx={{ marginTop: '32px' }} spacing={2} direction="row">
+            <Button variant="contained" onClick={() => downloadPreview()}>Save</Button>
+            <Button variant="contained" onClick={() => resetSchema()}>Reset</Button>
+        </Stack>
+    );
+}


### PR DESCRIPTION
# Overview
This change adds some handy buttons to the editor to save the current webp or to reset the schema.

# Demo

https://github.com/tidbyt/pixlet/assets/3886576/fff680fe-0b3d-4739-b096-f0a4c0d4131b

# Changes
- [feat: Add controls to web view.](https://github.com/tidbyt/pixlet/commit/022735e5e4ad876fce7f66fd2cfc7044c52c2bce)
    - This commit adds two buttons to the editor in a new section called "controls". One button will save the current view and the other will reset the editor.