### PR TITLE
Add a pure-browser version of the Pixlet UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,12 @@ examples/*.gif
 # Pixlet Binary
 pixlet
 pixlet.exe
+pixlet.wasm
 
 # Releases
 build/
 out/
+dist/
 
 # Dependency directories
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 	TAGS =
 endif
 
-all: build
+all: build wasm
 
 test:
 	go test $(TAGS) -v -cover ./...
@@ -24,7 +24,7 @@ bench:
 	go test -benchmem -benchtime=20s -bench BenchmarkRunAndRender tidbyt.dev/pixlet/encode
 
 build:
-	 go build $(LDFLAGS) $(TAGS) -o $(BINARY) tidbyt.dev/pixlet
+	go build $(LDFLAGS) $(TAGS) -o $(BINARY) tidbyt.dev/pixlet
 
 embedfonts:
 	go run render/gen/embedfonts.go
@@ -51,3 +51,6 @@ lint:
 	buildifier -r ./
 
 format: lint
+
+wasm:
+	GOOS=js GOARCH=wasm go build -o ./src/pixlet.wasm tidbyt.dev/pixlet

--- a/cmd/community/community.go
+++ b/cmd/community/community.go
@@ -5,7 +5,6 @@ import (
 )
 
 func init() {
-	CommunityCmd.AddCommand(CreateManifestCmd)
 	CommunityCmd.AddCommand(ListIconsCmd)
 	CommunityCmd.AddCommand(LoadAppCmd)
 	CommunityCmd.AddCommand(SpellCheckCmd)

--- a/cmd/community/createmanifest.go
+++ b/cmd/community/createmanifest.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package community
 
 import (
@@ -16,6 +18,10 @@ var CreateManifestCmd = &cobra.Command{
 	Long:    `This command creates an app manifest by asking a series of prompts.`,
 	Args:    cobra.ExactArgs(1),
 	RunE:    CreateManifest,
+}
+
+func init() {
+	CommunityCmd.AddCommand(CreateManifestCmd)
 }
 
 func CreateManifest(cmd *cobra.Command, args []string) error {

--- a/cmd/community/manifestprompt.go
+++ b/cmd/community/manifestprompt.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package community
 
 import (

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package cmd
 
 import (

--- a/encode/encode.go
+++ b/encode/encode.go
@@ -1,18 +1,10 @@
 package encode
 
 import (
-	"bytes"
 	"crypto/sha256"
-	"fmt"
 	"image"
-	"image/color"
-	"image/draw"
-	"image/gif"
-	"time"
 
-	"github.com/ericpauley/go-quantize/quantize"
 	"github.com/pkg/errors"
-	"github.com/tidbyt/go-libwebp/webp"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"tidbyt.dev/pixlet/render"
@@ -90,108 +82,6 @@ func (s *Screens) Hash() ([]byte, error) {
 
 	h := sha256.Sum256(j)
 	return h[:], nil
-}
-
-// Renders a screen to WebP. Optionally pass filters for
-// postprocessing each individual frame.
-func (s *Screens) EncodeWebP(maxDuration int, filters ...ImageFilter) ([]byte, error) {
-	images, err := s.render(filters...)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(images) == 0 {
-		return []byte{}, nil
-	}
-
-	bounds := images[0].Bounds()
-	anim, err := webp.NewAnimationEncoder(
-		bounds.Dx(),
-		bounds.Dy(),
-		WebPKMin,
-		WebPKMax,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "initializing encoder")
-	}
-	defer anim.Close()
-
-	remainingDuration := time.Duration(maxDuration) * time.Millisecond
-	for _, im := range images {
-		frameDuration := time.Duration(s.delay) * time.Millisecond
-
-		if maxDuration > 0 {
-			if frameDuration > remainingDuration {
-				frameDuration = remainingDuration
-			}
-			remainingDuration -= frameDuration
-		}
-
-		if err := anim.AddFrame(im, frameDuration); err != nil {
-			return nil, errors.Wrap(err, "adding frame")
-		}
-
-		if maxDuration > 0 && remainingDuration <= 0 {
-			break
-		}
-	}
-
-	buf, err := anim.Assemble()
-	if err != nil {
-		return nil, errors.Wrap(err, "encoding animation")
-	}
-
-	return buf, nil
-}
-
-// Renders a screen to GIF. Optionally pass filters for postprocessing
-// each individual frame.
-func (s *Screens) EncodeGIF(maxDuration int, filters ...ImageFilter) ([]byte, error) {
-	images, err := s.render(filters...)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(images) == 0 {
-		return []byte{}, nil
-	}
-
-	g := &gif.GIF{}
-
-	remainingDuration := maxDuration
-	for imIdx, im := range images {
-		imRGBA, ok := im.(*image.RGBA)
-		if !ok {
-			return nil, fmt.Errorf("image %d is %T, require RGBA", imIdx, im)
-		}
-
-		palette := quantize.MedianCutQuantizer{}.Quantize(make([]color.Color, 0, 256), im)
-		imPaletted := image.NewPaletted(imRGBA.Bounds(), palette)
-		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{0, 0}, draw.Src)
-
-		frameDelay := int(s.delay)
-		if maxDuration > 0 {
-			if frameDelay > remainingDuration {
-				frameDelay = remainingDuration
-			}
-			remainingDuration -= frameDelay
-		}
-
-		g.Image = append(g.Image, imPaletted)
-		g.Delay = append(g.Delay, frameDelay/10) // in 100ths of a second
-
-		if maxDuration > 0 && remainingDuration <= 0 {
-			break
-		}
-	}
-
-	buf := &bytes.Buffer{}
-	err = gif.EncodeAll(buf, g)
-	if err != nil {
-		return nil, errors.Wrap(err, "encoding")
-	}
-
-	return buf.Bytes(), nil
 }
 
 func (s *Screens) render(filters ...ImageFilter) ([]image.Image, error) {

--- a/encode/gif.go
+++ b/encode/gif.go
@@ -1,0 +1,63 @@
+package encode
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/gif"
+
+	"github.com/ericpauley/go-quantize/quantize"
+	"github.com/pkg/errors"
+)
+
+// Renders a screen to GIF. Optionally pass filters for postprocessing
+// each individual frame.
+func (s *Screens) EncodeGIF(maxDuration int, filters ...ImageFilter) ([]byte, error) {
+	images, err := s.render(filters...)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(images) == 0 {
+		return []byte{}, nil
+	}
+
+	g := &gif.GIF{}
+
+	remainingDuration := maxDuration
+	for imIdx, im := range images {
+		imRGBA, ok := im.(*image.RGBA)
+		if !ok {
+			return nil, fmt.Errorf("image %d is %T, require RGBA", imIdx, im)
+		}
+
+		palette := quantize.MedianCutQuantizer{}.Quantize(make([]color.Color, 0, 256), im)
+		imPaletted := image.NewPaletted(imRGBA.Bounds(), palette)
+		draw.Draw(imPaletted, imRGBA.Bounds(), imRGBA, image.Point{0, 0}, draw.Src)
+
+		frameDelay := int(s.delay)
+		if maxDuration > 0 {
+			if frameDelay > remainingDuration {
+				frameDelay = remainingDuration
+			}
+			remainingDuration -= frameDelay
+		}
+
+		g.Image = append(g.Image, imPaletted)
+		g.Delay = append(g.Delay, frameDelay/10) // in 100ths of a second
+
+		if maxDuration > 0 && remainingDuration <= 0 {
+			break
+		}
+	}
+
+	buf := &bytes.Buffer{}
+	err = gif.EncodeAll(buf, g)
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding")
+	}
+
+	return buf.Bytes(), nil
+}

--- a/encode/webp.go
+++ b/encode/webp.go
@@ -1,0 +1,62 @@
+//go:build !js && !wasm
+
+package encode
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/tidbyt/go-libwebp/webp"
+)
+
+// Renders a screen to WebP. Optionally pass filters for
+// postprocessing each individual frame.
+func (s *Screens) EncodeWebP(maxDuration int, filters ...ImageFilter) ([]byte, error) {
+	images, err := s.render(filters...)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(images) == 0 {
+		return []byte{}, nil
+	}
+
+	bounds := images[0].Bounds()
+	anim, err := webp.NewAnimationEncoder(
+		bounds.Dx(),
+		bounds.Dy(),
+		WebPKMin,
+		WebPKMax,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing encoder")
+	}
+	defer anim.Close()
+
+	remainingDuration := time.Duration(maxDuration) * time.Millisecond
+	for _, im := range images {
+		frameDuration := time.Duration(s.delay) * time.Millisecond
+
+		if maxDuration > 0 {
+			if frameDuration > remainingDuration {
+				frameDuration = remainingDuration
+			}
+			remainingDuration -= frameDuration
+		}
+
+		if err := anim.AddFrame(im, frameDuration); err != nil {
+			return nil, errors.Wrap(err, "adding frame")
+		}
+
+		if maxDuration > 0 && remainingDuration <= 0 {
+			break
+		}
+	}
+
+	buf, err := anim.Assemble()
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding animation")
+	}
+
+	return buf, nil
+}

--- a/encode/webp_js.go
+++ b/encode/webp_js.go
@@ -1,0 +1,13 @@
+//go:build js && wasm
+
+package encode
+
+import (
+	"fmt"
+)
+
+// Renders a screen to WebP. Optionally pass filters for
+// postprocessing each individual frame.
+func (s *Screens) EncodeWebP(maxDuration int, filters ...ImageFilter) ([]byte, error) {
+	return nil, fmt.Errorf("WebP not supported in WASM")
+}

--- a/encode/webp_js.go
+++ b/encode/webp_js.go
@@ -2,12 +2,9 @@
 
 package encode
 
-import (
-	"fmt"
-)
-
 // Renders a screen to WebP. Optionally pass filters for
 // postprocessing each individual frame.
 func (s *Screens) EncodeWebP(maxDuration int, filters ...ImageFilter) ([]byte, error) {
-	return nil, fmt.Errorf("WebP not supported in WASM")
+	// lol you gullible sucker, you thought you could use webp in wasm?
+	return s.EncodeGIF(maxDuration, filters...)
 }

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,8 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/nlepage/go-js-promise v1.0.0 // indirect
+	github.com/nlepage/go-wasm-http-server v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,10 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20220510032225-4f9f17eaec4c h1:4RYnE0ISVwRxm9Dfo7utw1dh0kdRDEmVYq2MFVLy5zI=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20220510032225-4f9f17eaec4c/go.mod h1:DvuJJ/w1Y59rG8UTDxsMk5U+UJXJwuvUgbiJSm9yhX8=
+github.com/nlepage/go-js-promise v1.0.0 h1:K7OmJ3+0BgWJ2LfXchg2sI6RDr7AW/KWR8182epFwGQ=
+github.com/nlepage/go-js-promise v1.0.0/go.mod h1:bdOP0wObXu34euibyK39K1hoBCtlgTKXGc56AGflaRo=
+github.com/nlepage/go-wasm-http-server v1.1.0 h1:phw2NtSp71m/6NmGjE2veQ41PBPzWFcnE614cKucy5M=
+github.com/nlepage/go-wasm-http-server v1.1.0/go.mod h1:xpffUeN97vuv8CTlMJ2oC5tPsftfPoG9HkAgI9gkiPI=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/paulmach/orb v0.1.5/go.mod h1:pPwxxs3zoAyosNSbNKn1jiXV2+oovRDObDKfTvRegDI=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ func init() {
 	rootCmd.AddCommand(cmd.DevicesCmd)
 	rootCmd.AddCommand(cmd.FormatCmd)
 	rootCmd.AddCommand(cmd.LintCmd)
-	rootCmd.AddCommand(cmd.CreateCmd)
 	rootCmd.AddCommand(cmd.CheckCmd)
 	rootCmd.AddCommand(cmd.BundleCmd)
 	rootCmd.AddCommand(cmd.UploadCmd)

--- a/main_nonjs.go
+++ b/main_nonjs.go
@@ -1,0 +1,11 @@
+//go:build !js && !wasm
+
+package main
+
+import (
+	"tidbyt.dev/pixlet/cmd"
+)
+
+func init() {
+	rootCmd.AddCommand(cmd.CreateCmd)
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "start": "webpack serve --config webpack.dev.js",
+    "start:wasm": "make wasm && PIXLET_BACKEND=wasm webpack serve --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
+    "build:wasm": "make wasm && PIXLET_BACKEND=wasm webpack --config webpack.prod.js",
     "clean": "rm -rf dist/static/ && git restore dist/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/render/image.go
+++ b/render/image.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/nfnt/resize"
 	"github.com/tidbyt/gg"
-	"github.com/tidbyt/go-libwebp/webp"
 )
 
 // Image renders the binary image data passed via `src`. Supported
@@ -55,25 +54,6 @@ func (p *Image) Size() (int, int) {
 
 func (p *Image) FrameCount() int {
 	return len(p.imgs)
-}
-
-func (p *Image) InitFromWebP(data []byte) error {
-	decoder, err := webp.NewAnimationDecoder(data)
-	if err != nil {
-		return fmt.Errorf("creating animation decoder: %v", err)
-	}
-
-	img, err := decoder.Decode()
-	if err != nil {
-		return fmt.Errorf("decoding image data: %v", err)
-	}
-
-	p.Delay = img.Timestamp[0]
-	for _, im := range img.Image {
-		p.imgs = append(p.imgs, im)
-	}
-
-	return nil
 }
 
 func (p *Image) InitFromGIF(data []byte) error {

--- a/render/image_webp.go
+++ b/render/image_webp.go
@@ -1,0 +1,28 @@
+//go:build !js && !wasm
+
+package render
+
+import (
+	"fmt"
+
+	"github.com/tidbyt/go-libwebp/webp"
+)
+
+func (p *Image) InitFromWebP(data []byte) error {
+	decoder, err := webp.NewAnimationDecoder(data)
+	if err != nil {
+		return fmt.Errorf("creating animation decoder: %v", err)
+	}
+
+	img, err := decoder.Decode()
+	if err != nil {
+		return fmt.Errorf("decoding image data: %v", err)
+	}
+
+	p.Delay = img.Timestamp[0]
+	for _, im := range img.Image {
+		p.imgs = append(p.imgs, im)
+	}
+
+	return nil
+}

--- a/render/image_webp_js.go
+++ b/render/image_webp_js.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package render
+
+import (
+	"fmt"
+)
+
+func (p *Image) InitFromWebP(data []byte) error {
+	return fmt.Errorf("WebP not supported in WASM")
+}

--- a/server/browser/browser.go
+++ b/server/browser/browser.go
@@ -112,11 +112,6 @@ func (b *Browser) Run() error {
 	return g.Wait()
 }
 
-func (b *Browser) serveHTTP() error {
-	log.Printf("listening at http://%s\n", b.addr)
-	return http.ListenAndServe(b.addr, b.r)
-}
-
 func (b *Browser) faviconHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "image/png")
 	w.Write(favicon)

--- a/server/browser/serve.go
+++ b/server/browser/serve.go
@@ -1,0 +1,13 @@
+//go:build !js && !wasm
+
+package browser
+
+import (
+	"log"
+	"net/http"
+)
+
+func (b *Browser) serveHTTP() error {
+	log.Printf("listening at http://%s\n", b.addr)
+	return http.ListenAndServe(b.addr, b.r)
+}

--- a/server/browser/serve_js.go
+++ b/server/browser/serve_js.go
@@ -1,0 +1,14 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	wasmhttp "github.com/nlepage/go-wasm-http-server"
+	"log"
+)
+
+func (b *Browser) serveHTTP() error {
+	log.Printf("listening via wasmhttp")
+	wasmhttp.Serve(b.r)
+	return nil
+}

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 
 	"tidbyt.dev/pixlet/encode"
@@ -27,6 +26,7 @@ type Loader struct {
 	updatesChan      chan Update
 	resultsChan      chan Update
 	maxDuration      int
+	initialLoad      chan bool
 }
 
 type Update struct {
@@ -57,6 +57,7 @@ func NewLoader(
 		requestedChanges: make(chan bool, 100),
 		resultsChan:      make(chan Update, 100),
 		maxDuration:      maxDuration,
+		initialLoad:      make(chan bool),
 	}
 
 	cache := runtime.NewInMemoryCache()
@@ -65,6 +66,7 @@ func NewLoader(
 
 	if !l.watch {
 		err := loadScript(&l.applet, l.filename)
+		l.markInitialLoadComplete()
 		if err != nil {
 			return nil, err
 		}
@@ -130,6 +132,8 @@ func (l *Loader) LoadApplet(config map[string]string) (string, error) {
 }
 
 func (l *Loader) GetSchema() []byte {
+	<-l.initialLoad
+
 	s := []byte(l.applet.GetSchema())
 	if len(s) > 0 {
 		return s
@@ -140,12 +144,14 @@ func (l *Loader) GetSchema() []byte {
 }
 
 func (l *Loader) CallSchemaHandler(ctx context.Context, handlerName, parameter string) (string, error) {
+	<-l.initialLoad
 	return l.applet.CallSchemaHandler(ctx, handlerName, parameter)
 }
 
 func (l *Loader) loadApplet(config map[string]string) (string, error) {
 	if l.watch {
 		err := loadScript(&l.applet, l.filename)
+		l.markInitialLoadComplete()
 		if err != nil {
 			return "", err
 		}
@@ -170,16 +176,11 @@ func (l *Loader) loadApplet(config map[string]string) (string, error) {
 	return base64.StdEncoding.EncodeToString(webp), nil
 }
 
-func loadScript(applet *runtime.Applet, filename string) error {
-	src, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return fmt.Errorf("failed to read file %s: %w", filename, err)
+func (l *Loader) markInitialLoadComplete() {
+	// safely close the l.initialLoad channel to signal that the initial load is complete
+	select {
+	case <-l.initialLoad:
+	default:
+		close(l.initialLoad)
 	}
-
-	err = applet.Load(filename, src, nil)
-	if err != nil {
-		return fmt.Errorf("failed to load applet: %w", err)
-	}
-
-	return nil
 }

--- a/server/loader/script.go
+++ b/server/loader/script.go
@@ -1,0 +1,24 @@
+//go:build !js && !wasm
+
+package loader
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"tidbyt.dev/pixlet/runtime"
+)
+
+func loadScript(applet *runtime.Applet, filename string) error {
+	src, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", filename, err)
+	}
+
+	err = applet.Load(filename, src, nil)
+	if err != nil {
+		return fmt.Errorf("failed to load applet: %w", err)
+	}
+
+	return nil
+}

--- a/server/loader/script_js.go
+++ b/server/loader/script_js.go
@@ -1,0 +1,31 @@
+//go:build js && wasm
+
+package loader
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"tidbyt.dev/pixlet/runtime"
+)
+
+func loadScript(applet *runtime.Applet, filename string) error {
+	res, err := http.Get(filename)
+	if err != nil {
+		return fmt.Errorf("failed to fetch file %s: %w", filename, err)
+	}
+	defer res.Body.Close()
+
+	src, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %w", filename, err)
+	}
+
+	err = applet.Load(filename, src, nil)
+	if err != nil {
+		return fmt.Errorf("failed to load applet: %w", err)
+	}
+
+	return nil
+}

--- a/server/watcher/fs.go
+++ b/server/watcher/fs.go
@@ -1,0 +1,49 @@
+//go:build !js && !wasm
+
+package watcher
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Run starts the file watcher in a blocking fashion. This watches an entire
+// directory and only notifies the channel when the specified file is changed.
+// If there is an error, it's returned. It's up to the caller to respawn the
+// watcher if it's desireable to keep watching.
+//
+// The reason it watches a directory is becausde some editers like VIM write
+// to a swap file and recreate the original file. So we can't simply watch the
+// original file, we have to watch the directory. This is also why we check both
+// the WRITE and CREATE events since VIM will write to a swap and then create
+// the file on save. VSCode does a WRITE and then a CHMOD, so tracking WRITE
+// catches the changes for VSCode exactly once.
+func (w *Watcher) Run() error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("error watching for changes: %w", err)
+	}
+	defer watcher.Close()
+
+	watcher.Add(filepath.Dir(w.filename))
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return fmt.Errorf("something is weird with the file watcher")
+			}
+			if event.Name == w.filename && (event.Op&(fsnotify.Write|fsnotify.Create)) != 0 {
+				w.fileChanges <- true
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return fmt.Errorf("something is weird with the file watcher around error handling")
+			}
+			return fmt.Errorf("error in file watcher: %w", err)
+		}
+	}
+}

--- a/server/watcher/fs_js.go
+++ b/server/watcher/fs_js.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package watcher
+
+import (
+	"fmt"
+)
+
+func (w *Watcher) Run() error {
+	return fmt.Errorf("file watching not supported in WASM")
+}

--- a/server/watcher/watcher.go
+++ b/server/watcher/watcher.go
@@ -2,10 +2,7 @@
 package watcher
 
 import (
-	"fmt"
 	"path/filepath"
-
-	"github.com/fsnotify/fsnotify"
 )
 
 // Watcher is a structure to watch a file for changes and notify a channel.
@@ -20,44 +17,5 @@ func NewWatcher(filename string, fileChanges chan bool) *Watcher {
 	return &Watcher{
 		filename:    filepath.FromSlash(filename),
 		fileChanges: fileChanges,
-	}
-}
-
-// Run starts the file watcher in a blocking fashion. This watches an entire
-// directory and only notifies the channel when the specified file is changed.
-// If there is an error, it's returned. It's up to the caller to respawn the
-// watcher if it's desireable to keep watching.
-//
-// The reason it watches a directory is becausde some editers like VIM write
-// to a swap file and recreate the original file. So we can't simply watch the
-// original file, we have to watch the directory. This is also why we check both
-// the WRITE and CREATE events since VIM will write to a swap and then create
-// the file on save. VSCode does a WRITE and then a CHMOD, so tracking WRITE
-// catches the changes for VSCode exactly once.
-func (w *Watcher) Run() error {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("error watching for changes: %w", err)
-	}
-	defer watcher.Close()
-
-	watcher.Add(filepath.Dir(w.filename))
-
-	for {
-		select {
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return fmt.Errorf("something is weird with the file watcher")
-			}
-			if event.Name == w.filename && (event.Op&(fsnotify.Write|fsnotify.Create)) != 0 {
-				w.fileChanges <- true
-			}
-
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return fmt.Errorf("something is weird with the file watcher around error handling")
-			}
-			return fmt.Errorf("error in file watcher: %w", err)
-		}
 	}
 }

--- a/src/apps/cms.star
+++ b/src/apps/cms.star
@@ -1,0 +1,273 @@
+"""
+Applet: CMS
+Summary: CMS Backend
+Description: An app that supports creating a CMS display.
+Author: Tidbyt
+"""
+
+load("encoding/base64.star", "base64")
+load("render.star", "render")
+load("schema.star", "schema")
+
+DEFAULT_DISPLAY_TYPE = "horizontal"
+
+DEFAULT_BACKGROUND_COLOR = "#000000"
+
+DEFAULT_HEADING = "Example"
+DEFAULT_HEADING_COLOR = "#7AB0FF"
+DEFAULT_HIDE_HEADING = False
+
+DEFAULT_BODY = "Example body text that is a bit longer than the heading text."
+DEFAULT_BODY_COLOR = "#FFFFFF"
+DEFAULT_HIDE_BODY = False
+
+DEFAULT_HIDE_LOGO = False
+DEFAULT_LOGO = """
+iVBORw0KGgoAAAANSUhEUgAAABAAAAASCAYAAABSO15qAAAACXBIWXMAAC4jAAAuIwF4pT92AAABFklE
+QVQ4jZXTzU7CQBQF4K+kLBCRRCNCqkRf06fyPfxjQ2JcGk1cqRElYaF10ZlQYGjwJE2nt+eeOXPn3uzy
+qtSAz/A+2EbIt8Q76KMXvgu8Y75ObCWSj/AQnogpHjFoEshwjAnGwUFEP7iY4CRwNwRK3OA04SpihNvA
+XRHIgvK4ITmiCEJZXaCD67pyA8rA7bK8hRbOdkiObou4eXRQ4mNHAar+KOsC33azH1FiVhc4lu6JbWhh
+GBcD3Gto1wT2cYdhjme0/5FMVcgRnnL8YIHf8LPEm82aZDi07MIM7Vx1/myN3EvEWE5nRJnjK0GcBkfR
+RaY6ZrFOTI1zVzWRe2vxharQKy5SVzfHBV5Udz3DK87DegV/vJUy/l4a2gQAAAAASUVORK5CYII=
+"""
+
+def main(config):
+    display_type = config.str("display_type", DEFAULT_DISPLAY_TYPE)
+
+    if display_type == "horizontal":
+        return render_horizontal(config)
+
+    return render_vertical(config)
+
+def render_horizontal(config):
+    background_color = config.str("background_color", DEFAULT_BACKGROUND_COLOR)
+
+    heading = config.str("heading", DEFAULT_HEADING)
+    heading_color = config.str("heading_color", DEFAULT_HEADING_COLOR)
+    hide_heading = config.bool("hide_heading", DEFAULT_HIDE_HEADING)
+
+    body = config.str("body", DEFAULT_BODY)
+    body_color = config.str("body_color", DEFAULT_BODY_COLOR)
+    hide_body = config.bool("hide_body", DEFAULT_HIDE_BODY)
+
+    logo = config.str("logo", DEFAULT_LOGO)
+    hide_logo = config.bool("hide_logo", DEFAULT_HIDE_LOGO)
+
+    row_one = []
+    if not hide_logo:
+        row_one.append(
+            render.Image(
+                src = base64.decode(logo),
+            ),
+        )
+
+    if not hide_heading:
+        row_one.append(
+            render.Text(
+                content = heading,
+                color = heading_color,
+            ),
+        )
+
+    column_one = []
+    if len(row_one) != 0:
+        column_one.append(
+            render.Row(
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "center",
+                children = row_one,
+            ),
+        )
+
+    if not hide_body:
+        column_one.append(
+            render.Marquee(
+                width = 60,
+                child = render.Text(
+                    content = body,
+                    color = body_color,
+                ),
+            ),
+        )
+
+    if len(column_one) == 0:
+        return []
+
+    return render.Root(
+        show_full_animation = True,
+        child = render.Box(
+            padding = 2,
+            color = background_color,
+            child = render.Column(
+                expanded = True,
+                main_align = "space_around",
+                cross_align = "center",
+                children = column_one,
+            ),
+        ),
+    )
+
+def render_vertical(config):
+    background_color = config.str("background_color", DEFAULT_BACKGROUND_COLOR)
+
+    heading = config.str("heading", DEFAULT_HEADING)
+    heading_color = config.str("heading_color", DEFAULT_HEADING_COLOR)
+    hide_heading = config.bool("hide_heading", DEFAULT_HIDE_HEADING)
+
+    body = config.str("body", DEFAULT_BODY)
+    body_color = config.str("body_color", DEFAULT_BODY_COLOR)
+    hide_body = config.bool("hide_body", DEFAULT_HIDE_BODY)
+
+    logo = config.str("logo", DEFAULT_LOGO)
+    hide_logo = config.bool("hide_logo", DEFAULT_HIDE_LOGO)
+
+    children = []
+    if not hide_logo:
+        children.append(
+            render.Row(
+                cross_align = "center",
+                main_align = "space_around",
+                expanded = True,
+                children = [
+                    render.Image(
+                        src = base64.decode(logo),
+                    ),
+                ],
+            ),
+        )
+        children.append(render.Box(height = 4))
+
+    if not hide_heading:
+        children.append(
+            render.Row(
+                cross_align = "center",
+                main_align = "space_around",
+                expanded = True,
+                children = [
+                    render.Text(
+                        content = heading,
+                        color = heading_color,
+                    ),
+                ],
+            ),
+        )
+        children.append(render.Box(height = 4))
+
+    if not hide_body:
+        children.append(
+            render.WrappedText(content = body, color = body_color),
+        )
+        children.append(render.Box(height = 10, width = 1))
+
+    if len(children) == 0:
+        return []
+
+    return render.Root(
+        show_full_animation = True,
+        delay = 60,
+        child = render.Box(
+            color = background_color,
+            child = render.Marquee(
+                height = 32,
+                offset_start = 16,
+                offset_end = 32,
+                scroll_direction = "vertical",
+                child = render.Padding(
+                    pad = 1,
+                    child = render.Column(
+                        main_align = "start",
+                        children = children,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+def get_schema():
+    options = [
+        schema.Option(
+            display = "Horizontal Scroll",
+            value = DEFAULT_DISPLAY_TYPE,
+        ),
+        schema.Option(
+            display = "Vertical Scroll",
+            value = "vertical",
+        ),
+    ]
+
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Dropdown(
+                id = "display_type",
+                name = "Display Type",
+                desc = "The type of display to use.",
+                icon = "display",
+                default = DEFAULT_DISPLAY_TYPE,
+                options = options,
+            ),
+            schema.Color(
+                id = "background_color",
+                name = "Background Color",
+                desc = "Background color for the display.",
+                icon = "brush",
+                default = DEFAULT_BACKGROUND_COLOR,
+            ),
+            schema.Text(
+                id = "heading",
+                name = "Heading Text",
+                desc = "The heading text to display",
+                icon = "textHeight",
+                default = DEFAULT_HEADING,
+            ),
+            schema.Color(
+                id = "heading_color",
+                name = "Heading Color",
+                desc = "Heading text color.",
+                icon = "brush",
+                default = DEFAULT_HEADING_COLOR,
+            ),
+            schema.Toggle(
+                id = "hide_heading",
+                name = "Hide Heading",
+                desc = "A toggle to hide the heading text.",
+                icon = "eyeSlash",
+                default = DEFAULT_HIDE_HEADING,
+            ),
+            schema.Text(
+                id = "body",
+                name = "Body Text",
+                desc = "The body text to display",
+                icon = "textHeight",
+                default = DEFAULT_BODY,
+            ),
+            schema.Color(
+                id = "body_color",
+                name = "Body Color",
+                desc = "Body text color.",
+                icon = "brush",
+                default = DEFAULT_BODY_COLOR,
+            ),
+            schema.Toggle(
+                id = "hide_body",
+                name = "Hide Body",
+                desc = "A toggle to hide the body text.",
+                icon = "eyeSlash",
+                default = DEFAULT_HIDE_BODY,
+            ),
+            schema.PhotoSelect(
+                id = "logo",
+                name = "Logo",
+                desc = "A logo to display.",
+                icon = "photoFilm",
+            ),
+            schema.Toggle(
+                id = "hide_logo",
+                name = "Hide Logo",
+                desc = "A toggle to hide the logo.",
+                icon = "eyeSlash",
+                default = DEFAULT_HIDE_LOGO,
+            ),
+        ],
+    )

--- a/src/features/handlers/actions.js
+++ b/src/features/handlers/actions.js
@@ -20,7 +20,7 @@ export function callHandler(id, handler, param) {
     }
 
     store.dispatch(loading(true));
-    axios.post('/api/v1/handlers/' + handler, JSON.stringify(data))
+    axios.post(`${PIXLET_API_BASE}/api/v1/handlers/` + handler, JSON.stringify(data))
         .then(res => {
             store.dispatch(update({ id: id, value: res.data }));
         })
@@ -42,7 +42,7 @@ export function callGeneratedHandler(id, handler, param) {
     }
 
     store.dispatch(loading(true));
-    axios.post('/api/v1/handlers/' + handler, JSON.stringify(data))
+    axios.post(`${PIXLET_API_BASE}/api/v1/handlers/` + handler, JSON.stringify(data))
         .then(res => {
             store.dispatch(updateGenerated(res.data));
         })
@@ -64,7 +64,7 @@ export function callHandlerSetValue(id, handler, param, valueHandler) {
     }
 
     store.dispatch(loading(true));
-    axios.post('/api/v1/handlers/' + handler, JSON.stringify(data))
+    axios.post(`${PIXLET_API_BASE}/api/v1/handlers/` + handler, JSON.stringify(data))
         .then(res => {
             store.dispatch(update({ id: id, value: res.data }));
             valueHandler(res.data);

--- a/src/features/preview/actions.js
+++ b/src/features/preview/actions.js
@@ -6,7 +6,7 @@ import store from '../../store';
 
 export default function fetchPreview(formData) {
     store.dispatch(loading(true));
-    axios.post('/api/v1/preview', formData)
+    axios.post(`${PIXLET_API_BASE}/api/v1/preview`, formData)
         .then(res => {
             document.title = res.data.title;
             store.dispatch(update(res.data));

--- a/src/features/schema/actions.js
+++ b/src/features/schema/actions.js
@@ -7,7 +7,7 @@ import store from "../../store";
 export default function refreshSchema() {
     store.dispatch(loading(true));
 
-    axios.get('/api/v1/schema')
+    axios.get(`${PIXLET_API_BASE}/api/v1/schema`)
         .then(res => {
             store.dispatch(update(res.data));
         })

--- a/src/features/watcher/WatcherManager.jsx
+++ b/src/features/watcher/WatcherManager.jsx
@@ -4,6 +4,11 @@ import Watcher from './watcher';
 
 
 export default function WatcherManager() {
+    if (PIXLET_WASM) {
+        // watcher isn't supported in the browser
+        return null;
+    }
+
     useEffect(() => {
         new Watcher();
     }, []);

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import OAuth2Handler from './features/schema/fields/oauth2/OAuth2Handler';
 import store from './store';
 import DevToolsTheme from './features/theme/DevToolsTheme';
 
-
 const App = () => {
     return (
         <Provider store={store}>
@@ -24,4 +23,17 @@ const App = () => {
     )
 }
 
-ReactDOM.render(<App />, document.getElementById('app'));
+if (PIXLET_WASM && 'serviceWorker' in navigator) {
+    window.addEventListener('load', function () {
+        navigator.serviceWorker.register(new URL('./sw.js', import.meta.url)).then(function (registration) {
+            // Registration was successful
+            console.log('ServiceWorker registration successful with scope: ', registration.scope);
+            ReactDOM.render(<App />, document.getElementById('app'));
+        }, function (err) {
+            // registration failed :(
+            console.log('ServiceWorker registration failed: ', err);
+        });
+    });
+} else {
+    ReactDOM.render(<App />, document.getElementById('app'));
+}

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,22 @@
+import cmsStarlark from './apps/cms.star';
+
+importScripts('https://cdn.jsdelivr.net/gh/golang/go@go1.18.4/misc/wasm/wasm_exec.js');
+importScripts('https://cdn.jsdelivr.net/gh/nlepage/go-wasm-http-server@v1.1.0/sw.js');
+
+registerWasmHTTPListener(
+    new URL('./pixlet.wasm', import.meta.url),
+    {
+        'base': 'pixlet',
+        'args': ['serve', cmsStarlark],
+    }
+);
+
+// Skip installed stage and jump to activating stage
+addEventListener('install', (event) => {
+    event.waitUntil(skipWaiting())
+});
+
+// Start controlling clients as soon as the SW is activated
+addEventListener('activate', event => {
+    event.waitUntil(clients.claim())
+});

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,31 @@
+const webpack = require('webpack');
+
+let plugins = [];
+
+if (process.env.PIXLET_BACKEND === "wasm") {
+    plugins.push(
+        new webpack.DefinePlugin({
+            'PIXLET_WASM': JSON.stringify(true),
+            'PIXLET_API_BASE': JSON.stringify('pixlet'),
+        })
+    );
+} else {
+    plugins.push(
+        new webpack.DefinePlugin({
+            'PIXLET_WASM': JSON.stringify(false),
+            'PIXLET_API_BASE': JSON.stringify(''),
+        })
+    );
+}
+
 module.exports = {
+    plugins,
     resolve: {
         extensions: ['*', '.js', '.jsx'],
+    },
+    experiments: {
+        asyncWebAssembly: true,
+        syncWebAssembly: true
     },
     module: {
         rules: [
@@ -24,7 +49,7 @@ module.exports = {
                 ],
             },
             {
-                test: /\.(webp|jpe?g|gif)$/i,
+                test: /\.(webp|jpe?g|gif|star)$/i,
                 use: [
                     {
                         loader: 'file-loader',


### PR DESCRIPTION
Adds a WASM backend mode for Pixlet, which builds `pixlet.wasm` and
loads it in the browser. This WASM binary then runs Starlark, without
the need for the `pixlet` Go backend.

Use `npm run start:wasm` to try it.