### PR TITLE
Don't package dist/static into WASM build

### DIFF
--- a/dist/dist.go
+++ b/dist/dist.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package dist
 
 import "embed"

--- a/dist/dist_js.go
+++ b/dist/dist_js.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package dist
+
+import "embed"
+
+// dummy values not used in wasm build
+var (
+	Static embed.FS
+	Index  []byte
+)


### PR DESCRIPTION
The WASM binary never serves these static files, so they don't need to be embedded into it. These reduces the size of the WASM binary from around 160 MB to around 50 MB uncompressed.