### PR TITLE
wasm: Use raw images instead of the cropper.

### DIFF
--- a/src/features/schema/FieldDetails.jsx
+++ b/src/features/schema/FieldDetails.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import OAuth2 from './fields/oauth2/OAuth2';
 import PhotoSelect from './fields/photoselect/PhotoSelect';
+import RawPhotoSelect from './fields/photoselect/RawPhotoSelect';
 import Toggle from './fields/Toggle';
 import Color from './fields/Color';
 import DateTime from './fields/DateTime';
@@ -26,6 +27,9 @@ export default function FieldDetails({ field }) {
         case 'oauth2':
             return <OAuth2 field={field} />
         case 'png':
+            if (PIXLET_WASM) {
+                return <RawPhotoSelect field={field} />
+            }
             return <PhotoSelect field={field} />
         case 'text':
             return <TextInput field={field} />

--- a/src/features/schema/fields/photoselect/RawPhotoSelect.jsx
+++ b/src/features/schema/fields/photoselect/RawPhotoSelect.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import Cropper from 'react-easy-crop';
+import { useSelector, useDispatch } from 'react-redux';
+
+import Button from '@mui/material/Button';
+import Modal from '@mui/material/Modal';
+import PhotoCamera from '@mui/icons-material/PhotoCamera';
+import Slider from '@mui/material/Slider';
+import Stack from '@mui/material/Stack';
+import DeleteIcon from '@mui/icons-material/Delete';
+import Box from '@mui/material/Box';
+
+import { set, remove } from '../../../config/configSlice';
+import getCroppedImg from './cropImage';
+import styles from './styles.css';
+
+
+export default function RawPhotoSelect({ field }) {
+    const config = useSelector(state => state.config);
+    const dispatch = useDispatch();
+    const [image, setImage] = useState("");
+
+    useEffect(() => {
+        if (field.id in config) {
+            setImage(config[field.id].value);
+        } else if (field.default) {
+            setImage(field.default);
+            dispatch(set({
+                id: field.id,
+                value: field.default,
+            }));
+        }
+    }, [config])
+
+    const handleCapture = ({ target }) => {
+        const fileReader = new FileReader();
+        fileReader.readAsDataURL(target.files[0]);
+        fileReader.onload = (e) => {
+            let base64String = e.target.result.split(",")[1];
+            setImage(base64String);
+            dispatch(set({
+                id: field.id,
+                value: base64String,
+            }));
+
+        };
+    }
+
+    const handleClear = () => {
+        setImage("");
+        dispatch(remove(field.id));
+    };
+
+    let buttons;
+
+    if (image) {
+        buttons = <Stack spacing={2} direction="row">
+            <Button
+                variant="contained"
+                component="label"
+                startIcon={<PhotoCamera htmlColor='white' />}
+            >
+                Upload Image
+                <input
+                    accept="image/*"
+                    type="file"
+                    hidden
+                    onChange={handleCapture}
+                />
+            </Button >
+            <Button
+                variant="contained"
+                onClick={handleClear}
+                startIcon={<DeleteIcon htmlColor='white' />}
+            >
+                Clear Image
+            </Button >
+        </Stack>
+    } else {
+        buttons = <Button
+            variant="contained"
+            component="label"
+            startIcon={<PhotoCamera htmlColor='white' />}
+        >
+            Upload Image
+            <input
+                accept="image/*"
+                type="file"
+                hidden
+                onChange={handleCapture}
+            />
+        </Button >
+    }
+
+    return (
+        <React.Fragment>
+            {buttons}
+        </React.Fragment>
+    );
+}


### PR DESCRIPTION
This is a bit of a hack. The main use case for WASM pixlet is to be able to support a CMS based editor. While this doesn't match what the mobile app would do, it's a better experience for our CMS editor.