### PR TITLE
Bundle Go/WASM dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 
 # Dependency directories
 node_modules
+src/go

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ format: lint
 
 wasm:
 	GOOS=js GOARCH=wasm go build -trimpath -ldflags="-s -w" -o ./src/pixlet.wasm tidbyt.dev/pixlet
+	mkdir -p ./src/go
+	cp -f $(shell go env GOROOT)/misc/wasm/wasm_exec.js ./src/go/wasm_exec.js
+	cp -f $(shell go list -m -f '{{.Dir}}' github.com/nlepage/go-wasm-http-server)/sw.js ./src/go/sw.js

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,7 +1,7 @@
 import cmsStarlark from './apps/cms.star';
 
-importScripts('https://cdn.jsdelivr.net/gh/golang/go@go1.18.4/misc/wasm/wasm_exec.js');
-importScripts('https://cdn.jsdelivr.net/gh/nlepage/go-wasm-http-server@v1.1.0/sw.js');
+importScripts(new URL('./go/wasm_exec.js', import.meta.url));
+importScripts(new URL('./go/sw.js', import.meta.url));
 
 registerWasmHTTPListener(
     new URL('./pixlet.wasm', import.meta.url),


### PR DESCRIPTION
Instead of relying on an external CDN, get `wasm_exec.js` and `sw.js` dependencies from the local `GOROOT` and bundle them with our distribution.

This ensures that we always are using the correct version of these scripts. It should also reduce latency since we're serving them from our own server.