### PR TITLE
wasm: Detect if the platform is iOS and return a message.

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -14,6 +14,7 @@ import Preview from './features/preview/Preview';
 import Schema from './features/schema/Schema';
 import WatcherManager from './features/watcher/WatcherManager';
 import Controls from './features/controls/Controls';
+import { Typography } from '@mui/material';
 
 
 export default function Main() {
@@ -23,6 +24,42 @@ export default function Main() {
     if (schema.value.schema.length > 0) {
         size = 8;
     }
+
+    function iOS() {
+        return [
+            'iPad Simulator',
+            'iPhone Simulator',
+            'iPod Simulator',
+            'iPad',
+            'iPhone',
+            'iPod'
+        ].includes(navigator.platform)
+    };
+
+    if (PIXLET_WASM && iOS()) {
+        return (
+            <ErrorSnackbar >
+                <AppBar />
+                <Container maxWidth='xl' sx={{ marginTop: '32px' }}>
+                    <Box sx={{ flexGrow: 1 }}>
+                        <Grid container spacing={4}>
+                            <Grid item xs={12} lg={12}>
+                                <Typography variant='h4' sx={{ textAlign: 'center' }} color='text.secondary'>
+                                    Sorry, iOS is not supported.
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={12} lg={12}>
+                                <Typography sx={{ textAlign: 'center' }} color='text.secondary'>
+                                    Please try again on a desktop browser.
+                                </Typography>
+                            </Grid>
+                        </Grid>
+                    </Box>
+                </Container>
+            </ErrorSnackbar>
+        );
+    }
+
 
     return (
         <ErrorSnackbar >


### PR DESCRIPTION
This commit detects if the requesting platform is iOS and returns an unsupported message. We're getting the following error on iOS with WASM pixlet and I suspect it's due to the callstack of the pixlet binary being larger then iOS supports in browser:
> Unhandled Promise Rejection: RangeError: Maximum call stack size exceeded.