### PR TITLE
feat: Add profile to pixlet check.

### DIFF
--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.starlark.net/starlark"
 	"tidbyt.dev/pixlet/runtime"
 )
 
@@ -34,8 +35,15 @@ func LoadApp(cmd *cobra.Command, args []string) error {
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
 
+	// Remove the print function from the starlark thread.
+	initializers := []runtime.ThreadInitializer{}
+	initializers = append(initializers, func(thread *starlark.Thread) *starlark.Thread {
+		thread.Print = func(thread *starlark.Thread, msg string) {}
+		return thread
+	})
+
 	applet := runtime.Applet{}
-	err = applet.Load(script, src, nil)
+	err = applet.LoadWithInitializers(script, src, nil, initializers...)
 	if err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -92,6 +92,10 @@ func (a *Applet) thread(initializers ...ThreadInitializer) *starlark.Thread {
 // and the actual code should be passed in src. Optionally also pass
 // loader to make additional starlark modules available to the script.
 func (a *Applet) Load(filename string, src []byte, loader ModuleLoader) (err error) {
+	return a.LoadWithInitializers(filename, src, loader)
+}
+
+func (a *Applet) LoadWithInitializers(filename string, src []byte, loader ModuleLoader, initializers ...ThreadInitializer) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic while executing %s: %v", a.Filename, r)
@@ -116,7 +120,7 @@ func (a *Applet) Load(filename string, src []byte, loader ModuleLoader) (err err
 		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
 	}
 
-	globals, err := starlark.ExecFile(a.thread(), a.Filename, a.src, a.predeclared)
+	globals, err := starlark.ExecFile(a.thread(initializers...), a.Filename, a.src, a.predeclared)
 	if err != nil {
 		return fmt.Errorf("starlark.ExecFile: %v", err)
 	}


### PR DESCRIPTION
# Overview
We want to start checking app performance as part of the PR process in the community repo. This change updates the check process to ensure the app can render and it's runtime is under 500ms. 

# Considerations
7.5% of the apps in the community repo will fail this check today. Given we only check apps that changed, they will effectively be grandfathered in. If we find that 500ms is too slow, we will consider relaxing this check.

The other thing to consider is this check could be gamed - the default config is what we are profiling, and as we saw with centipede in arcade classics, sometimes the perf issues are not the default or blank config.

# Changes
- [feat: Add profile to pixlet check.](https://github.com/tidbyt/pixlet/commit/47a73964e204fd6d12d1931ff900068a3a216fe6)
    - This change adds profiling to the pixlet check command. In addition, it adds a render check given it needs to be able to render before we can profile an app. Finally, I've made improvements to output silencing so the pixlet check output is clear.