### PR TITLE
Bug fix: only render one frame at a time in Sequence

### DIFF
--- a/render/sequence.go
+++ b/render/sequence.go
@@ -65,6 +65,7 @@ func (s Sequence) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 			dc.Push()
 			c.Paint(dc, bounds, frameIdx-fc)
 			dc.Pop()
+			break
 		}
 
 		fc += c.FrameCount()

--- a/render/sequence_test.go
+++ b/render/sequence_test.go
@@ -1,0 +1,43 @@
+package render
+
+import (
+  "image"
+  "image/color"
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+)
+
+func TestSequenceOnlyOneFrameAtATime(t *testing.T) {
+  seq := Sequence{
+    Children: []Widget {
+      Box{Width: 3, Height: 3, Color: color.RGBA{0xff, 0, 0, 0xff}},
+      Box{Width: 6, Height: 3, Color: color.RGBA{0, 0xff, 0, 0xff}},
+      Box{Width: 9, Height: 3, Color: color.RGBA{0, 0, 0xff, 0xff}},
+    },
+  }
+
+  // Frame 0
+  im := PaintWidget(seq, image.Rect(0, 0, 10, 3), 0)
+  assert.Equal(t, nil, checkImage([]string{
+    "rrr",
+    "rrr",
+    "rrr",
+  }, im))
+
+  // Frame 1
+  im = PaintWidget(seq, image.Rect(0, 0, 10, 3), 1)
+  assert.Equal(t, nil, checkImage([]string{
+    "gggggg",
+    "gggggg",
+    "gggggg",
+  }, im))
+
+  // Frame 2
+  im = PaintWidget(seq, image.Rect(0, 0, 10, 3), 2)
+  assert.Equal(t, nil, checkImage([]string{
+    "bbbbbbbbb",
+    "bbbbbbbbb",
+    "bbbbbbbbb",
+  }, im))
+}


### PR DESCRIPTION
Previously, `Sequence` would paint a frame from each child after the given frame index, meaning graphics from multiple children get painted atop each other in the same output frame resulting in a garbled appearance.

Now, we break out of the loop after a single frame has been painted. This PR also adds a test verifying this behavior.

This appears to have been broken since the introduction of Sequence in #222 and seems like it would affect most uses of Sequence (?), so I'm not sure how this wasn't caught in the year+ since then.