### PR TITLE
Add bsoup module

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,6 +28,7 @@ individual modules, please refer to the Starlib documentation.
 
 | Module | Description |
 | --- | --- |
+| [`bsoup.star`](https://github.com/qri-io/starlib/blob/master/bsoup) | Beautiful Soup-like functions for HTML |
 | [`compress/gzip.star`](https://github.com/qri-io/starlib/blob/master/compress/gzip) | gzip decompressing |
 | [`compress/zipfile.star`](https://github.com/qri-io/starlib/blob/master/zipfile) | zip decompressing |
 | [`encoding/base64.star`](https://github.com/qri-io/starlib/tree/master/encoding/base64) | Base 64 encoding and decoding |

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e h1:44fmjqDtdCiUNlSjJVp+w1AOs6na3Y6Ai0aIeseFjkI=
 github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e/go.mod h1:CgNC6SGbT+Xb8wGGvzilttZL1mc5sQ/5KkcxsZttMIk=
 github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819 h1:RIB4cRk+lBqKK3Oy0r2gRX4ui7tuhiZq2SuTtTCi0/0=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	starlibgzip "github.com/qri-io/starlib/compress/gzip"
 	starlibbase64 "github.com/qri-io/starlib/encoding/base64"
+	starlibbsoup "github.com/qri-io/starlib/bsoup"
 	starlibcsv "github.com/qri-io/starlib/encoding/csv"
 	starlibhash "github.com/qri-io/starlib/hash"
 	starlibhtml "github.com/qri-io/starlib/html"
@@ -315,6 +316,9 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 
 	case "xpath.star":
 		return xpath.LoadXPathModule()
+
+	case "bsoup.star":
+		return starlibbsoup.LoadModule()
 
 	case "compress/gzip.star":
 		return starlark.StringDict{

--- a/runtime/applet_test.go
+++ b/runtime/applet_test.go
@@ -181,6 +181,7 @@ func TestModuleLoading(t *testing.T) {
 	// Our basic set of modules can be imported
 	src := `
 load("render.star", "render")
+load("bsoup.star", "bsoup")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
@@ -205,6 +206,8 @@ def main():
         fail("re broken")
     if time.parse_duration("10s").seconds != 10:
         fail("time broken")
+    if bsoup.parseHtml("<h1>foo</h1>").find("h1").get_text() != "foo":
+    	fail("bsoup broken")
     return render.Root(child=render.Box())
 `
 	app := &Applet{}


### PR DESCRIPTION
Responding to request on forum: https://discuss.tidbyt.com/t/beautiful-soup-python-supported/5328/2

I can imagine you saying no, because this provides similar functionality to the existing html module. But I agree with the poster that this is a better API and I would prefer to be able to use it.