### PR TITLE
canvas: Replace TransformPoint/DrawPixel with AddPixel

### DIFF
--- a/render/canvas/canvas.go
+++ b/render/canvas/canvas.go
@@ -32,6 +32,9 @@ type Canvas interface {
 	// AddLineTo adds a line to the current path, from the current point to (x, y).
 	AddLineTo(x, y float64)
 
+	// AddPixel adds a pixel to the current path at (x, y).
+	AddPixel(x, y int)
+
 	// AddRectangle adds a rectangle to the current path.
 	AddRectangle(x, y, w, h float64)
 
@@ -46,9 +49,6 @@ type Canvas interface {
 
 	// DrawImageFromBuffer draws the given image at (x, y).
 	DrawImageFromBuffer(x, y, w, h float64, img []byte)
-
-	// DrawPixel draws a pixel at (x, y).
-	DrawPixel(x, y int)
 
 	// DrawString draws the given text at (x, y).
 	DrawString(x, y float64, text string)
@@ -84,9 +84,6 @@ type Canvas interface {
 
 	// SetFont sets the current font.
 	SetFont(font *fonts.Font)
-
-	// TransformPoint does a thing.
-	TransformPoint(x, y float64) (ax, ay float64)
 
 	// Translate translates the canvas by (dx, dy) for future drawing operations.
 	Translate(dx, dy float64)

--- a/render/canvas/gg.go
+++ b/render/canvas/gg.go
@@ -32,6 +32,10 @@ func (c *GGCanvas) AddLineTo(x, y float64) {
 	c.dc.LineTo(x, y)
 }
 
+func (c *GGCanvas) AddPixel(x, y int) {
+	c.dc.DrawRectangle(float64(x), float64(y), 1, 1)
+}
+
 func (c *GGCanvas) AddRectangle(x, y, w, h float64) {
 	c.dc.DrawRectangle(x, y, w, h)
 }
@@ -52,10 +56,6 @@ func (c *GGCanvas) DrawGoImage(x, y float64, img image.Image) {
 func (c *GGCanvas) DrawImageFromBuffer(x, y, w, h float64, img []byte) {
 	im, _, _ := image.Decode(bytes.NewReader(img))
 	c.dc.DrawImage(im, int(x), int(y))
-}
-
-func (c *GGCanvas) DrawPixel(x, y int) {
-	c.dc.SetPixel(x, y)
 }
 
 func (c *GGCanvas) DrawString(x, y float64, text string) {
@@ -115,10 +115,6 @@ func (c *GGCanvas) SetColor(color color.Color) {
 func (c *GGCanvas) SetFont(font *fonts.Font) {
 	c.currentFontFace = font.Font.NewFace()
 	c.dc.SetFontFace(c.currentFontFace)
-}
-
-func (c *GGCanvas) TransformPoint(x, y float64) (ax, ay float64) {
-	return c.dc.TransformPoint(x, y)
 }
 
 func (c *GGCanvas) Translate(dx, dy float64) {

--- a/render/plot.go
+++ b/render/plot.go
@@ -231,14 +231,14 @@ func (p Plot) Paint(dc canvas.Canvas, bounds image.Rectangle, frameIdx int) {
 		if y > p.invThreshold {
 			dc.SetColor(fillColInv)
 			for ; y != p.invThreshold && y >= 0; y-- {
-				tx, ty := dc.TransformPoint(float64(x), float64(y))
-				dc.DrawPixel(int(tx), int(ty))
+				dc.AddPixel(x, y)
+				dc.FillPath()
 			}
 		} else {
 			dc.SetColor(fillCol)
 			for ; y <= p.invThreshold && y <= p.Height; y++ {
-				tx, ty := dc.TransformPoint(float64(x), float64(y))
-				dc.DrawPixel(int(tx), int(ty))
+				dc.AddPixel(x, y)
+				dc.FillPath()
 			}
 		}
 	}
@@ -252,7 +252,8 @@ func (p Plot) Paint(dc canvas.Canvas, bounds image.Rectangle, frameIdx int) {
 			} else {
 				dc.SetColor(col)
 			}
-			dc.DrawPixel(int(point.X), int(point.Y))
+			dc.AddPixel(point.X, point.Y)
+			dc.FillPath()
 		}
 	} else {
 		// the line itself
@@ -263,8 +264,8 @@ func (p Plot) Paint(dc canvas.Canvas, bounds image.Rectangle, frameIdx int) {
 			} else {
 				dc.SetColor(col)
 			}
-			tx, ty := dc.TransformPoint(float64(x), float64(y))
-			dc.DrawPixel(int(tx), int(ty))
+			dc.AddPixel(x, y)
+			dc.FillPath()
 		}
 	}
 }

--- a/render/starfield.go
+++ b/render/starfield.go
@@ -61,23 +61,23 @@ func DrawLine(dc canvas.Canvas, x0, y0, x1, y1 int) {
 
 	if dx == 0 {
 		for ; y0 != y1; y0 += sy {
-			dc.DrawPixel(x0, y0)
+			dc.AddPixel(x0, y0)
 		}
-		dc.DrawPixel(x0, y0)
+		dc.AddPixel(x0, y0)
 		return
 	}
 
 	if dy == 0 {
 		for ; x0 != x1; x0 += sx {
-			dc.DrawPixel(x0, y0)
+			dc.AddPixel(x0, y0)
 		}
-		dc.DrawPixel(x0, y0)
+		dc.AddPixel(x0, y0)
 		return
 	}
 
 	err := dx + dy
 
-	dc.DrawPixel(x0, y0)
+	dc.AddPixel(x0, y0)
 	for x0 != x1 && y0 != y1 {
 		e2 := 2 * err
 		if e2 >= dy {
@@ -88,7 +88,7 @@ func DrawLine(dc canvas.Canvas, x0, y0, x1, y1 int) {
 			err += dx
 			y0 += sy
 		}
-		dc.DrawPixel(x0, y0)
+		dc.AddPixel(x0, y0)
 	}
 }
 
@@ -141,9 +141,11 @@ func (s *Starfield) Paint(dc canvas.Canvas, bounds image.Rectangle, frameIdx int
 		if pX != 0 && pY != 0 && (pX != X || pY != Y) {
 			dc.SetColor(color.RGBA{0x22, 0x22, 0x22, 0xff})
 			DrawLine(dc, pX, pY, X, Y)
+			dc.FillPath()
 		}
 		dc.SetColor(color.RGBA{0xff, 0xff, 0xff, 0xff})
-		dc.DrawPixel(X, Y)
+		dc.AddPixel(X, Y)
+		dc.FillPath()
 	}
 
 	dc.SetColor(color.RGBA{0xff, 0xff, 0xff, 0xff})

--- a/render/tracer.go
+++ b/render/tracer.go
@@ -26,14 +26,14 @@ func (t Tracer) Paint(dc canvas.Canvas, bounds image.Rectangle, frameIdx int) {
 	x, y := t.Path.Point(frameIdx)
 
 	dc.SetColor(color.RGBA{0xff, 0xff, 0xff, 0xff})
-	tx, ty := dc.TransformPoint(float64(x), float64(y))
-	dc.DrawPixel(int(tx), int(ty))
+	dc.AddPixel(x, y)
+	dc.FillPath()
 
 	for i := 0; i < t.TraceLength; i++ {
 		col := uint8(0xdd - i*(0xff/t.TraceLength))
 		dc.SetColor(color.RGBA{col, col, col, 0xff})
 		x, y := t.Path.Point(frameIdx - (i + 1))
-		tx, ty := dc.TransformPoint(float64(x), float64(y))
-		dc.DrawPixel(int(tx), int(ty))
+		dc.AddPixel(x, y)
+		dc.FillPath()
 	}
 }


### PR DESCRIPTION
Instead of having each widget (like `Plot`) have to call `TransformPoint` and then separately draw a pixel, add a new `AddPixel` that works like all the other canvas path commands.