### PR TITLE
Clean up bundle API for loading bundles

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -34,7 +34,7 @@ type AppBundle struct {
 	Source   fs.FS
 }
 
-func fromFS(fs fs.FS) (*AppBundle, error) {
+func FromFS(fs fs.FS) (*AppBundle, error) {
 	m, err := fs.Open(manifest.ManifestFileName)
 	if err != nil {
 		return nil, fmt.Errorf("could not open manifest: %w", err)
@@ -53,10 +53,10 @@ func fromFS(fs fs.FS) (*AppBundle, error) {
 	}, nil
 }
 
-// InitFromPath translates a directory containing an app manifest and source
+// FromDir translates a directory containing an app manifest and source
 // into an AppBundle.
-func InitFromPath(dir string) (*AppBundle, error) {
-	return fromFS(os.DirFS(dir))
+func FromDir(dir string) (*AppBundle, error) {
+	return FromFS(os.DirFS(dir))
 }
 
 // LoadBundle loads a compressed archive into an AppBundle.
@@ -78,7 +78,7 @@ func LoadBundle(in io.Reader) (*AppBundle, error) {
 		return nil, fmt.Errorf("creating tarfs: %w", err)
 	}
 
-	return fromFS(fs)
+	return FromFS(fs)
 }
 
 // WriteBundleToPath is a helper to be able to write the bundle to a provided

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestBundleWriteAndLoad(t *testing.T) {
 	// Ensure we can load the bundle from an app.
-	ab, err := bundle.InitFromPath("testdata/testapp")
+	ab, err := bundle.FromDir("testdata/testapp")
 	assert.NoError(t, err)
 	assert.Equal(t, "test-app", ab.Manifest.ID)
 	assert.NotNil(t, ab.Source)

--- a/cmd/private/bundle.go
+++ b/cmd/private/bundle.go
@@ -42,7 +42,7 @@ be a gzip compressed tar file that can be uploaded to Tidbyt for deployment.`,
 			return fmt.Errorf("output must be a directory")
 		}
 
-		ab, err := bundle.InitFromPath(bundleInput)
+		ab, err := bundle.FromDir(bundleInput)
 		if err != nil {
 			return fmt.Errorf("could not init bundle: %w", err)
 		}

--- a/cmd/private/upload.go
+++ b/cmd/private/upload.go
@@ -63,7 +63,7 @@ flags.`,
 
 		// Create bundle
 		buf := &bytes.Buffer{}
-		ab, err := bundle.InitFromPath(uploadDir)
+		ab, err := bundle.FromDir(uploadDir)
 		if err != nil {
 			return fmt.Errorf("could not init bundle: %w", err)
 		}


### PR DESCRIPTION
This is mostly important for embedders like the Tidbyt backend.