### PR TITLE
Provide file name in load errors

### DIFF
--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -409,7 +409,7 @@ func (a *Applet) ensureLoaded(fsys fs.FS, pathToLoad string, currentlyLoading ..
 				Recursion: true,
 			},
 			thread,
-			a.ID,
+			path.Join(a.ID, pathToLoad),
 			src,
 			predeclared,
 		)


### PR DESCRIPTION
When loading a Starlark file fails with an error, provide the name of the file. Since apps can now contain multiple files, this is necessary for the error message to make sense.