### PR TITLE
ci: Enable caching of Go modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -54,9 +57,6 @@ jobs:
             curl
             mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -52,9 +55,6 @@ jobs:
             curl
             mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
-
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-22.04'


### PR DESCRIPTION
Run the checkout action first so that `go.sum` is available for `checkout-go` to cache things.