### PR TITLE
Serve GIFs as well as WebP

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,6 +10,7 @@ var (
 	host  string
 	port  int
 	watch bool
+	serveGif bool
 )
 
 func init() {
@@ -18,6 +19,7 @@ func init() {
 	ServeCmd.Flags().BoolVarP(&watch, "watch", "w", true, "Reload scripts on change. Does not recurse sub-directories.")
 	ServeCmd.Flags().IntVarP(&maxDuration, "max_duration", "d", 15000, "Maximum allowed animation duration (ms)")
 	ServeCmd.Flags().IntVarP(&timeout, "timeout", "", 30000, "Timeout for execution (ms)")
+	ServeCmd.Flags().BoolVarP(&serveGif, "gif", "", false, "Generate GIF instead of WebP")
 }
 
 var ServeCmd = &cobra.Command{
@@ -33,7 +35,7 @@ containing multiple Starlark files and resources.`,
 }
 
 func serve(cmd *cobra.Command, args []string) error {
-	s, err := server.NewServer(host, port, watch, args[0], maxDuration, timeout)
+	s, err := server.NewServer(host, port, watch, args[0], maxDuration, timeout, serveGif)
 	if err != nil {
 		return err
 	}

--- a/server/browser/preview.html
+++ b/server/browser/preview.html
@@ -20,7 +20,7 @@
 
 <body bgcolor="black">
 	<div style="border: solid 1px white">
-		<img id="render" src="data:image/webp;base64,{{ .WebP }}" />
+		<img id="render" src="data:image/{{ .ImageType }};base64,{{ .Image }}" />
 	</div>
 	<div>
 		<p id="errors" style="color: red;">{{ .Err }}</p>
@@ -53,8 +53,8 @@
 				const err = document.getElementById("errors");
 
 				switch (data.type) {
-					case "webp":
-						img.src = "data:image/webp;base64," + data.message;
+					case "img":
+						img.src = "data:image/" + data.img_type + ";base64," + data.message;
 						err.innerHTML = "";
 						break;
 					case "error":

--- a/server/browser/push.go
+++ b/server/browser/push.go
@@ -53,12 +53,12 @@ func (b *Browser) pushHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	webp, err := b.loader.LoadApplet(config)
+	img, err := b.loader.LoadApplet(config)
 
 	payload, err := json.Marshal(
 		TidbytPushJSON{
 			DeviceID:       deviceID,
-			Image:          webp,
+			Image:          img,
 			InstallationID: installationID,
 			Background:     background,
 		},

--- a/server/fanout/client.go
+++ b/server/fanout/client.go
@@ -52,7 +52,7 @@ func (f *Fanout) NewClient(conn *websocket.Conn) *Client {
 	return c
 }
 
-// Send is used to send a webp message to the client.
+// Send is used to send an image message to the client.
 func (c *Client) Send(event WebsocketEvent) {
 	c.send <- event
 }
@@ -82,7 +82,7 @@ func (c *Client) reader() {
 	}
 }
 
-// writer writes webp events over the socket when it recieves messages via
+// writer writes image events over the socket when it recieves messages via
 // Send(). It also sends pings to ensure the connection stays alive.
 func (c *Client) writer() {
 	ticker := time.NewTicker(pingPeriod)

--- a/server/fanout/event.go
+++ b/server/fanout/event.go
@@ -1,23 +1,26 @@
 package fanout
 
 const (
-	// EventTypeWebP is used to signal what type of message we are sending over
+	// EventTypeImage is used to signal what type of message we are sending over
 	// the socket.
-	EventTypeWebP = "webp"
+	EventTypeImage = "img"
 
 	// EventTypeSchema is used to signal that the schema for a given app has
 	// changed.
 	EventTypeSchema = "schema"
 
 	// EventTypeErr is used to signal there was an error encountered rendering
-	// the WebP image.
+	// the image.
 	EventTypeErr = "error"
 )
 
 // WebsocketEvent is a structure used to send messages over the socket.
 type WebsocketEvent struct {
-	// Message is the contents of the message. This is a webp, base64 encoded.
+	// Message is the contents of the message. This is a webp or gif, base64 encoded.
 	Message string `json:"message"`
+
+	// ImageType indicates whether the Message is webp or gif image.
+	ImageType string `json:"img_type"`
 
 	// Type is the type of message we are sending over the socket.
 	Type string `json:"type"`

--- a/server/server.go
+++ b/server/server.go
@@ -23,7 +23,7 @@ type Server struct {
 }
 
 // NewServer creates a new server initialized with the applet.
-func NewServer(host string, port int, watch bool, path string, maxDuration int, timeout int) (*Server, error) {
+func NewServer(host string, port int, watch bool, path string, maxDuration int, timeout int, serveGif bool) (*Server, error) {
 	fileChanges := make(chan bool, 100)
 
 	// check if path exists, and whether it is a directory or a file
@@ -47,13 +47,13 @@ func NewServer(host string, port int, watch bool, path string, maxDuration int, 
 	}
 
 	updatesChan := make(chan loader.Update, 100)
-	l, err := loader.NewLoader(fs, watch, fileChanges, updatesChan, maxDuration, timeout)
+	l, err := loader.NewLoader(fs, watch, fileChanges, updatesChan, maxDuration, timeout, serveGif)
 	if err != nil {
 		return nil, err
 	}
 
 	addr := fmt.Sprintf("%s:%d", host, port)
-	b, err := browser.NewBrowser(addr, filepath.Base(path), watch, updatesChan, l)
+	b, err := browser.NewBrowser(addr, filepath.Base(path), watch, updatesChan, l, serveGif)
 	if err != nil {
 		return nil, err
 	}

--- a/src/features/config/ConfigManager.jsx
+++ b/src/features/config/ConfigManager.jsx
@@ -33,7 +33,7 @@ export default function ConfigManager() {
             formData.set(id, item.value);
         });
 
-        if (!loading || !('webp' in preview)) {
+        if (!loading || !('img' in preview)) {
             updatePreviews(formData, params);
         }
     }, [config]);

--- a/src/features/controls/Controls.jsx
+++ b/src/features/controls/Controls.jsx
@@ -12,7 +12,7 @@ export default function Controls() {
     const dispatch = useDispatch();
 
     let imageType = 'webp';
-    if (PIXLET_WASM) {
+    if (PIXLET_WASM || preview.value.img_type === "gif") {
         imageType = 'gif';
     }
 
@@ -21,7 +21,7 @@ export default function Controls() {
         const element = document.createElement("a");
 
         // convert base64 to raw binary data held in a string
-        let byteCharacters = atob(preview.value.webp);
+        let byteCharacters = atob(preview.value.img);
 
         // create an ArrayBuffer with a size in bytes
         let arrayBuffer = new ArrayBuffer(byteCharacters.length);

--- a/src/features/preview/Preview.jsx
+++ b/src/features/preview/Preview.jsx
@@ -60,16 +60,16 @@ export default function Preview() {
     const preview = useSelector(state => state.preview);
 
     let displayType = 'data:image/webp;base64,';
-    if (PIXLET_WASM) {
+    if (PIXLET_WASM || preview.value.img_type === "gif") {
         displayType = 'data:image/gif;base64,';
     }
 
-    let webp = 'UklGRhoAAABXRUJQVlA4TA4AAAAvP8AHAAcQEf0PRET/Aw==';
-    if (preview.value.webp) {
-        webp = preview.value.webp;
+    let img = 'UklGRhoAAABXRUJQVlA4TA4AAAAvP8AHAAcQEf0PRET/Aw==';
+    if (preview.value.img) {
+        img = preview.value.img;
     }
 
-    let content = <img src={displayType + webp} className={styles.image} />
+    let content = <img src={displayType + img} className={styles.image} />
     if (preview.loading && PIXLET_WASM) {
         content = <img src={displayType + loading} className={styles.image} />
     }

--- a/src/features/preview/previewSlice.js
+++ b/src/features/preview/previewSlice.js
@@ -5,7 +5,8 @@ export const previewSlice = createSlice({
     initialState: {
         loading: false,
         value: {
-            webp: '',
+            img: '',
+            img_type: '',
             title: 'Pixlet',
         }
     },
@@ -13,8 +14,12 @@ export const previewSlice = createSlice({
         update: (state = initialState, action) => {
             let up = state;
 
-            if ('webp' in action.payload) {
-                up.value.webp = action.payload.webp;
+            if ('img' in action.payload) {
+                up.value.img = action.payload.img;
+            }
+
+            if ('img_type' in action.payload) {
+                up.value.img_type = action.payload.img_type;
             }
 
             if ('title' in action.payload) {

--- a/src/features/watcher/watcher.js
+++ b/src/features/watcher/watcher.js
@@ -27,9 +27,10 @@ export default class Watcher {
         const data = JSON.parse(e.data);
 
         switch (data.type) {
-            case 'webp':
+            case 'img':
                 store.dispatch(update({
-                    webp: data.message,
+                    img: data.message,
+                    img_type: data.img_type
                 }));
                 store.dispatch(clearErrors());
                 break;


### PR DESCRIPTION
Saw https://github.com/tidbyt/pixlet/issues/1005 and thought it was a fun little challenge.

Tested that this worked locally for:
 - Previewing with WebP (default)
 - Previewing with GIF (passing --gif flag)
 - Updating config using either format
 - Exporting image using either format

Inspected the images shown and confirmed that it does generate a WebP or GIF file as appropriate, and that the src element is set to the appropriate image type.