### PR TITLE
Handle background push without installation ID

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -55,6 +55,10 @@ func push(cmd *cobra.Command, args []string) error {
 		installationID = args[2]
 	}
 
+	if background && len(installationID) == 0 {
+		return fmt.Errorf("Background push won't do anything unless you also specify an installation ID")	
+	}
+
 	if apiToken == "" {
 		apiToken = os.Getenv(APITokenEnv)
 	}


### PR DESCRIPTION
Addressed https://github.com/tidbyt/pixlet/issues/1003. Someone got confused enough to write in (and I don't blame them). Seems more user friendly to point out the problem than to silently do nothing.