### PR TITLE
Fix file watching in `pixlet serve`

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"tidbyt.dev/pixlet/server"
@@ -33,6 +35,10 @@ containing multiple Starlark files and resources.`,
 }
 
 func serve(cmd *cobra.Command, args []string) error {
+	if watch && cmd.Flags().Changed("watch") {
+		fmt.Printf("explicitly setting --watch is unnecessary, since it's the default\n\n")
+	}
+
 	s, err := server.NewServer(host, port, watch, args[0], maxDuration, timeout)
 	if err != nil {
 		return err

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ func NewServer(host string, port int, watch bool, path string, maxDuration int, 
 	// check if path exists, and whether it is a directory or a file
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat %s: %w", path, err)
+		return nil, fmt.Errorf("stat'ing %s: %w", path, err)
 	}
 
 	var fs fs.FS
@@ -43,7 +43,7 @@ func NewServer(host string, port int, watch bool, path string, maxDuration int, 
 		}
 
 		fs = tools.NewSingleFileFS(path)
-		w = NewWatcher(filepath.Dir(path), fileChanges)
+		w = NewWatcher(path, fileChanges)
 	}
 
 	updatesChan := make(chan loader.Update, 100)


### PR DESCRIPTION
File watching was not working when using `pixlet serve` for a file in the working directory, or for `pixlet serve .`. This was due to a bug in how we handle file paths in the watcher.

Fixes #1067.