### PR TITLE
Add ID field for sounds

### DIFF
--- a/schema/notification_test.go
+++ b/schema/notification_test.go
@@ -16,6 +16,7 @@ load("sound.mp3", "file")
 
 sounds = [
 	schema.Sound(
+		id = "ding",
 		title = "Ding!",
 		file = file,
 	),
@@ -35,6 +36,7 @@ assert.eq(s.name, "New message")
 assert.eq(s.desc, "A new message has arrived")
 assert.eq(s.icon, "message")
 
+assert.eq(s.sounds[0].id, "ding")
 assert.eq(s.sounds[0].title, "Ding!")
 assert.eq(s.sounds[0].file, file)
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -65,6 +65,7 @@ type SchemaOption struct {
 
 // SchemaSound represents a sound that can be played by the applet.
 type SchemaSound struct {
+	ID    string `json:"id" validate:"required"`
 	Title string `json:"title" validate:"required"`
 	Path  string `json:"path" validate:"required"`
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -51,6 +51,7 @@ def get_schema():
                 icon = "notification",
                 sounds = [
                     schema.Sound(
+                        id = "ding",
                         title = "Ding!",
                         file = ding,
                     ),
@@ -162,6 +163,7 @@ def main():
 				Icon:        "notification",
 				Sounds: []schema.SchemaSound{
 					{
+						ID:    "ding",
 						Title: "Ding!",
 						Path:  "ding.mp3",
 					},
@@ -307,6 +309,7 @@ def get_schema():
                 icon = "notification",
                 sounds = [
                     schema.Sound(
+                        id = "ding",
                         title = "Ding!",
                         file = ding,
                     ),

--- a/schema/sound.go
+++ b/schema/sound.go
@@ -21,6 +21,7 @@ func newSound(
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
 	var (
+		id    starlark.String
 		title starlark.String
 		file  *file.File
 	)
@@ -28,6 +29,7 @@ func newSound(
 	if err := starlark.UnpackArgs(
 		"Sound",
 		args, kwargs,
+		"id", &id,
 		"title", &title,
 		"file", &file,
 	); err != nil {
@@ -35,6 +37,7 @@ func newSound(
 	}
 
 	s := &Sound{file: file}
+	s.ID = id.GoString()
 	s.Title = title.GoString()
 	s.Path = file.Path
 
@@ -46,11 +49,13 @@ func (s *Sound) AsSchemaSound() SchemaSound {
 }
 
 func (s *Sound) AttrNames() []string {
-	return []string{"title", "file"}
+	return []string{"id", "title", "file"}
 }
 
 func (s *Sound) Attr(name string) (starlark.Value, error) {
 	switch name {
+	case "id":
+		return starlark.String(s.ID), nil
 
 	case "title":
 		return starlark.String(s.Title), nil

--- a/schema/sound_test.go
+++ b/schema/sound_test.go
@@ -18,10 +18,12 @@ def assert(success, message=None):
         fail(message or "assertion failed")
 
 s = schema.Sound(
+	id = "sound1",
 	title = "Sneezing Elephant",
 	file = file,
 )
 
+assert(s.id == "sound1")
 assert(s.title == "Sneezing Elephant")
 assert(s.file == file)
 assert(s.file.readall() == "sound data")


### PR DESCRIPTION
Both the path and the contents of a notification sound could conceivably change without the sound being semantically different.

For example, `ding.mp3` could get renamed to `ding1.mp3`. Or a developer may re-encode `ding.mp3` to make it sound better.

In both cases, we need some sort of ID to keep a handle on the sound and know what to play.