### PR TITLE
schema: Allow handlers to be in separate files

### DIFF
--- a/schema/generated.go
+++ b/schema/generated.go
@@ -9,7 +9,6 @@ import (
 
 type Generated struct {
 	SchemaField
-	starlarkHandler *starlark.Function
 }
 
 func newGenerated(
@@ -35,7 +34,7 @@ func newGenerated(
 	}
 
 	s := &Generated{}
-	s.starlarkHandler = handler
+	s.StarlarkHandler = handler
 	s.Source = source.GoString()
 	s.Handler = handler.Name()
 	s.ID = id.GoString()
@@ -56,14 +55,15 @@ func (s *Generated) AttrNames() []string {
 
 func (s *Generated) Attr(name string) (starlark.Value, error) {
 	switch name {
-
 	case "source":
 		return starlark.String(s.Source), nil
 
 	case "handler":
-		return s.starlarkHandler, nil
+		return s.StarlarkHandler, nil
+
 	case "id":
 		return starlark.String(s.ID), nil
+
 	default:
 		return nil, nil
 	}

--- a/schema/locationbased.go
+++ b/schema/locationbased.go
@@ -9,7 +9,6 @@ import (
 
 type LocationBased struct {
 	SchemaField
-	starlarkHandler *starlark.Function
 }
 
 func newLocationBased(
@@ -45,7 +44,7 @@ func newLocationBased(
 	s.Description = desc.GoString()
 	s.Icon = icon.GoString()
 	s.Handler = handler.Name()
-	s.starlarkHandler = handler
+	s.StarlarkHandler = handler
 
 	return s, nil
 }
@@ -76,7 +75,7 @@ func (s *LocationBased) Attr(name string) (starlark.Value, error) {
 		return starlark.String(s.Icon), nil
 
 	case "handler":
-		return s.starlarkHandler, nil
+		return s.StarlarkHandler, nil
 
 	default:
 		return nil, nil

--- a/schema/oauth2.go
+++ b/schema/oauth2.go
@@ -9,8 +9,7 @@ import (
 
 type OAuth2 struct {
 	SchemaField
-	starlarkHandler *starlark.Function
-	starlarkScopes  *starlark.List
+	starlarkScopes *starlark.List
 }
 
 func newOAuth2(
@@ -52,7 +51,7 @@ func newOAuth2(
 	s.Description = desc.GoString()
 	s.Icon = icon.GoString()
 	s.Handler = handler.Name()
-	s.starlarkHandler = handler
+	s.StarlarkHandler = handler
 	s.ClientID = clientID.GoString()
 	s.AuthorizationEndpoint = authEndpoint.GoString()
 	s.starlarkScopes = scopes
@@ -109,7 +108,7 @@ func (s *OAuth2) Attr(name string) (starlark.Value, error) {
 		return starlark.String(s.Icon), nil
 
 	case "handler":
-		return s.starlarkHandler, nil
+		return s.StarlarkHandler, nil
 
 	case "client_id":
 		return starlark.String(s.ClientID), nil

--- a/schema/typeahead.go
+++ b/schema/typeahead.go
@@ -9,7 +9,6 @@ import (
 
 type Typeahead struct {
 	SchemaField
-	starlarkHandler *starlark.Function
 }
 
 func newTypeahead(
@@ -45,7 +44,7 @@ func newTypeahead(
 	s.Description = desc.GoString()
 	s.Icon = icon.GoString()
 	s.Handler = handler.Name()
-	s.starlarkHandler = handler
+	s.StarlarkHandler = handler
 
 	return s, nil
 }
@@ -76,7 +75,7 @@ func (s *Typeahead) Attr(name string) (starlark.Value, error) {
 		return starlark.String(s.Icon), nil
 
 	case "handler":
-		return s.starlarkHandler, nil
+		return s.StarlarkHandler, nil
 
 	default:
 		return nil, nil


### PR DESCRIPTION
Allow handler functions for schema fields to be imported from different files. Previously we were referencing handler functions by the function name.

Now we hold onto the Starlark reference so we can always find the function, even if it's imported from a different file.