### PR TITLE
Refactor the notifications schema definition

### DIFF
--- a/runtime/render_test.go
+++ b/runtime/render_test.go
@@ -161,7 +161,7 @@ def main():
 	app, err := NewApplet(filename, []byte(src))
 	assert.NoError(t, err)
 
-	b := app.globals["test_box.star"]["b"]
+	b := app.Globals["test_box.star"]["b"]
 	assert.IsType(t, &render_runtime.Box{}, b)
 
 	widget := b.(*render_runtime.Box).AsRenderWidget()
@@ -196,7 +196,7 @@ def main():
 	app, err := NewApplet(filename, []byte(src))
 	assert.NoError(t, err)
 
-	txt := app.globals["test_text.star"]["t"]
+	txt := app.Globals["test_text.star"]["t"]
 	assert.IsType(t, &render_runtime.Text{}, txt)
 
 	widget := txt.(*render_runtime.Text).AsRenderWidget()
@@ -240,7 +240,7 @@ def main():
 	app, err := NewApplet(filename, []byte(src))
 	assert.NoError(t, err)
 
-	starlarkP := app.globals["test_png.star"]["img"]
+	starlarkP := app.Globals["test_png.star"]["img"]
 	require.IsType(t, &render_runtime.Image{}, starlarkP)
 
 	actualIm := render.PaintWidget(starlarkP.(*render_runtime.Image).AsRenderWidget(), image.Rect(0, 0, 64, 32), 0)

--- a/schema/module.go
+++ b/schema/module.go
@@ -170,7 +170,7 @@ func newSchema(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 				)
 			}
 
-			s.Schema.Notifications = append(s.Schema.Notifications, n.AsSchemaField())
+			s.Schema.Notifications = append(s.Schema.Notifications, *n)
 		}
 	}
 

--- a/schema/notification.go
+++ b/schema/notification.go
@@ -9,6 +9,7 @@ import (
 
 type Notification struct {
 	SchemaField
+	Builder        *starlark.Function `json:"-"`
 	starlarkSounds *starlark.List
 }
 
@@ -19,11 +20,12 @@ func newNotification(
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
 	var (
-		id     starlark.String
-		name   starlark.String
-		desc   starlark.String
-		icon   starlark.String
-		sounds *starlark.List
+		id      starlark.String
+		name    starlark.String
+		desc    starlark.String
+		icon    starlark.String
+		sounds  *starlark.List
+		builder *starlark.Function
 	)
 
 	if err := starlark.UnpackArgs(
@@ -34,6 +36,7 @@ func newNotification(
 		"desc", &desc,
 		"icon", &icon,
 		"sounds", &sounds,
+		"builder", &builder,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Notification: %s", err)
 	}
@@ -44,6 +47,7 @@ func newNotification(
 	s.Name = name.GoString()
 	s.Description = desc.GoString()
 	s.Icon = icon.GoString()
+	s.Builder = builder
 
 	var soundVal starlark.Value
 	soundIter := sounds.Iterate()
@@ -75,7 +79,7 @@ func (s *Notification) AsSchemaField() SchemaField {
 
 func (s *Notification) AttrNames() []string {
 	return []string{
-		"id", "name", "desc", "icon", "sounds",
+		"id", "name", "desc", "icon", "sounds", "builder",
 	}
 }
 
@@ -96,6 +100,9 @@ func (s *Notification) Attr(name string) (starlark.Value, error) {
 
 	case "sounds":
 		return s.starlarkSounds, nil
+
+	case "builder":
+		return s.Builder, nil
 
 	default:
 		return nil, nil

--- a/schema/notification_test.go
+++ b/schema/notification_test.go
@@ -6,6 +6,7 @@ import (
 	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
+
 	"tidbyt.dev/pixlet/runtime"
 )
 
@@ -29,6 +30,7 @@ s = schema.Notification(
 	desc = "A new message has arrived",
 	icon = "message",
 	sounds = sounds,
+	builder = lambda: None,
 )
 
 assert.eq(s.id, "notification1")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -26,9 +26,9 @@ const (
 // Schema holds a configuration object for an applet. It holds a list of fields
 // that are exported from an applet.
 type Schema struct {
-	Version       string        `json:"version" validate:"required"`
-	Fields        []SchemaField `json:"schema" validate:"dive"`
-	Notifications []SchemaField `json:"notifications,omitempty" validate:"dive"`
+	Version       string         `json:"version" validate:"required"`
+	Fields        []SchemaField  `json:"schema" validate:"dive"`
+	Notifications []Notification `json:"notifications,omitempty" validate:"dive"`
 
 	Handlers map[string]SchemaHandler `json:"-"`
 }
@@ -107,7 +107,7 @@ func (s Schema) MarshalJSON() ([]byte, error) {
 		a.Fields = make([]SchemaField, 0)
 	}
 	if a.Notifications == nil {
-		a.Notifications = make([]SchemaField, 0)
+		a.Notifications = make([]Notification, 0)
 	}
 
 	js, err := json.Marshal(a)
@@ -165,6 +165,8 @@ func FromStarlark(
 		if schemaField.StarlarkHandler != nil {
 			handlerFun = schemaField.StarlarkHandler
 		} else if schemaField.Handler != "" {
+			// legacy schema, where the handler was a string instead of
+			// a function reference
 			handlerValue, ok := globals[schemaField.Handler]
 			if !ok {
 				return nil, fmt.Errorf(

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -39,6 +39,9 @@ def typeaheadhandler():
 def oauth2handler():
     return "a-refresh-token"
 
+def build_notification():
+    return None
+
 def get_schema():
     return schema.Schema(
         version = "1",
@@ -49,6 +52,7 @@ def get_schema():
                 name = "Notification",
                 desc = "A Notification",
                 icon = "notification",
+                builder = build_notification,
                 sounds = [
                     schema.Sound(
                         id = "ding",
@@ -154,18 +158,20 @@ def main():
 	assert.Equal(t, schema.Schema{
 		Version: "1",
 
-		Notifications: []schema.SchemaField{
+		Notifications: []schema.Notification{
 			{
-				Type:        "notification",
-				ID:          "notificationid",
-				Name:        "Notification",
-				Description: "A Notification",
-				Icon:        "notification",
-				Sounds: []schema.SchemaSound{
-					{
-						ID:    "ding",
-						Title: "Ding!",
-						Path:  "ding.mp3",
+				SchemaField: schema.SchemaField{
+					Type:        "notification",
+					ID:          "notificationid",
+					Name:        "Notification",
+					Description: "A Notification",
+					Icon:        "notification",
+					Sounds: []schema.SchemaSound{
+						{
+							ID:    "ding",
+							Title: "Ding!",
+							Path:  "ding.mp3",
+						},
 					},
 				},
 			},
@@ -307,6 +313,7 @@ def get_schema():
                 name = "Notification",
                 desc = "A Notification",
                 icon = "notification",
+                builder = lambda: None,
                 sounds = [
                     schema.Sound(
                         id = "ding",


### PR DESCRIPTION
Notifications are still a work in progress. With this change, each
notification needs to specify a `builder` function.

We also expose the Starlark globals and main file for embedders,
which is necessary for the background tasks proof-of-concept.