### PR TITLE
Add a .bytes() method to HTTP responses

### DIFF
--- a/runtime/modules/starlarkhttp/starlarkhttp.go
+++ b/runtime/modules/starlarkhttp/starlarkhttp.go
@@ -386,6 +386,7 @@ func (r *Response) Struct() *starlarkstruct.Struct {
 		"encoding":    starlark.String(strings.Join(r.TransferEncoding, ",")),
 
 		"body": starlark.NewBuiltin("body", r.Text),
+		"bytes": starlark.NewBuiltin("bytes", r.Bytes),
 		"json": starlark.NewBuiltin("json", r.JSON),
 	})
 }
@@ -412,6 +413,18 @@ func (r *Response) Text(thread *starlark.Thread, _ *starlark.Builtin, args starl
 	r.Body = io.NopCloser(bytes.NewReader(data))
 
 	return starlark.String(string(data)), nil
+}
+
+// Bytes returns the raw data as bytes
+func (r *Response) Bytes(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body.Close()
+	// reset reader to allow multiple calls
+	r.Body = io.NopCloser(bytes.NewReader(data))
+	return starlark.Bytes(data), nil
 }
 
 // JSON attempts to parse the response body as JSON


### PR DESCRIPTION
The new .bytes() method returns the body as bytes rather than a string. It is modeled after the .json() method, which parses the body as JSON.

The use case is parsing HTTP requests that return binary data. Certain operations on strings in Starlark don't work correctly with binary (i.e., non-UTF-8 encoded) data. In particular, when strings contain non-UTF-8 binary data, the `ord` function returns 65533 (the codepoint for the Unicode replacement character) when called on a byte with a value between 0x80 and 0xff. `ord` functions as expected with bytes values.