### PR TITLE
Fix Bitcoin Tracker example's Coindesk API URL

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -54,8 +54,8 @@ with the `font` parameter. You can read more about the available fonts
 
 To get closer to a truly useful Pixlet app, we'll be pulling in some
 Bitcoin data. CoinDesk's [Bitcoin Price Index
-API](https://www.coindesk.com/coindesk-api) is free to use and
-requires no authentication. We'll use Starlib's [http
+API](https://developers.coindesk.com/documentation/legacy/Price/SingleSymbolPriceEndpoint/)
+is free to use and requires no authentication. We'll use Starlib's [http
 module](https://github.com/qri-io/starlib/tree/master/http) to
 retrieve the data.
 
@@ -68,14 +68,14 @@ anything but the simplest applet.
 load("render.star", "render")
 load("http.star", "http")
 
-COINDESK_PRICE_URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+COINDESK_PRICE_URL = "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
 
 def main():
     rep = http.get(COINDESK_PRICE_URL)
     if rep.status_code != 200:
         fail("Coindesk request failed with status %d", rep.status_code)
 
-    rate = rep.json()["bpi"]["USD"]["rate_float"]
+    rate = rep.json()["USD"]
 
     return render.Root(
         child = render.Text("BTC: %d USD" % rate)
@@ -113,7 +113,7 @@ load("render.star", "render")
 load("http.star", "http")
 load("encoding/base64.star", "base64")
 
-COINDESK_PRICE_URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+COINDESK_PRICE_URL = "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
 
 # Load Bitcoin icon from base64 encoded data
 BTC_ICON = base64.decode("""
@@ -128,7 +128,7 @@ def main():
     if rep.status_code != 200:
         fail("CoinDesk request failed with status %d", rep.status_code)
 
-    rate = rep.json()["bpi"]["USD"]["rate_float"]
+    rate = rep.json()["USD"]
 
     return render.Root(
         child = render.Row( # Row lays out its children horizontally
@@ -166,7 +166,7 @@ load("render.star", "render")
 load("http.star", "http")
 load("encoding/base64.star", "base64")
 
-COINDESK_PRICE_URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+COINDESK_PRICE_URL = "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
 
 BTC_ICON = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAAAlklEQVQ4T2NkwAH+H2T/jy7FaP+
@@ -180,7 +180,7 @@ def main():
     if rep.status_code != 200:
         fail("Coindesk request failed with status %d", rep.status_code)
 
-    rate = rep.json()["bpi"]["USD"]["rate_float"]
+    rate = rep.json()["USD"]
 
     return render.Root(
         child = render.Box( # This Box exists to provide vertical centering
@@ -216,7 +216,7 @@ load("http.star", "http")
 load("encoding/base64.star", "base64")
 load("cache.star", "cache")
 
-COINDESK_PRICE_URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+COINDESK_PRICE_URL = "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
 
 BTC_ICON = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAAAlklEQVQ4T2NkwAH+H2T/jy7FaP+
@@ -235,7 +235,7 @@ def main():
         rep = http.get(COINDESK_PRICE_URL)
         if rep.status_code != 200:
             fail("Coindesk request failed with status %d", rep.status_code)
-        rate = rep.json()["bpi"]["USD"]["rate_float"]
+        rate = rep.json()["USD"]
         cache.set("btc_rate", str(int(rate)), ttl_seconds=240)
 
     return render.Root(

--- a/examples/bitcoin/bitcoin.star
+++ b/examples/bitcoin/bitcoin.star
@@ -2,7 +2,7 @@ load("http.star", "http")
 load("icon.png", icon = "file")
 load("render.star", "render")
 
-COINDESK_PRICE_URL = "https://api.coindesk.com/v1/bpi/currentprice.json"
+COINDESK_PRICE_URL = "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
 
 BTC_ICON = icon.readall()
 
@@ -10,7 +10,7 @@ def main():
     rep = http.get(COINDESK_PRICE_URL, ttl_seconds = 240)
     if rep.status_code != 200:
         fail("Coindesk request failed with status %d", rep.status_code)
-    rate = rep.json()["bpi"]["USD"]["rate_float"]
+    rate = rep.json()["USD"]
 
     return render.Root(
         child = render.Box(

--- a/examples/bitcoin/bitcoin.star
+++ b/examples/bitcoin/bitcoin.star
@@ -1,10 +1,16 @@
 load("http.star", "http")
-load("icon.png", icon = "file")
+load("encoding/base64.star", "base64")
 load("render.star", "render")
 
 COINDESK_PRICE_URL = "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
 
-BTC_ICON = icon.readall()
+# Load Bitcoin icon from base64 encoded data
+BTC_ICON = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAAAlklEQVQ4T2NkwAH+H2T/jy7FaP+
+TEZtyDEG4Zi0TTPXXzoDF0A1DMQRsADbN6MZdO4NiENwQbAbERh1lWLzMmgFGo5iFZBDYEFwuwG
+sISCPUIKyGgDRjAyBXYXMNIz5XgDQga8TpLboYgux8DO/AwoUuLiEqTLBFMcmxQ7V0gssgklIsL
+AYozjsoBoE45OZi5DRBSnkCAMLhlPBiQGHlAAAAAElFTkSuQmCC
+""")
 
 def main():
     rep = http.get(COINDESK_PRICE_URL, ttl_seconds = 240)


### PR DESCRIPTION
Coindesk updated their API and now has a "[Min API](https://developers.coindesk.com/documentation/legacy/Price/SingleSymbolPriceEndpoint/)" and "[Data API](https://developers.coindesk.com/documentation/data-api/introduction)". The Min API has the most minimum amount of data returned, and since this specific example just looks for the "price of 1 BTC in USD", it seems most reasonable to use.

This PR updates the API URL _and_ expected response JSON payload in the example star file and the tutorial doc.

This PR _also_ updates the example star file to read the image from a Base64 string. [PR#1045](https://github.com/tidbyt/pixlet/pull/1045) changed this functionality originally, stating Starlark now supports this; however, it doesn't appear to be actual Starlark functionality (but rather a custom Pixlet addition) and attempting to use `load("icon.png", icon = "file")` as-is yields the following error:

> error loading applet: starlark.ExecFile: cannot load icon.png: invalid module: icon.png

I have not updated any of the other references throughout the codebase, only the bitcoin tracker example, to "test the waters". I'm okay to take that piece out of this PR if desired -- but including it allows it to actually render 😅 

This should address [Issue #663](https://github.com/tidbyt/pixlet/issues/663) and [Issue #990](https://github.com/tidbyt/pixlet/issues/990).